### PR TITLE
Added bug from issue no. 18004 - jax

### DIFF
--- a/jax/issue_18004/reproduce_bug.sh
+++ b/jax/issue_18004/reproduce_bug.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+conda init
+conda create --name issue_18004 python==3.11 pip -y
+eval "$(conda shell.bash hook)"
+conda activate issue_18004
+pip install -r requirements.txt
+pytest -sx
+returncode=$?
+conda deactivate
+conda env remove --name issue_18004 -y
+exit ${returncode}

--- a/jax/issue_18004/requirements.txt
+++ b/jax/issue_18004/requirements.txt
@@ -1,0 +1,10 @@
+iniconfig==2.0.0
+jax[cpu]==0.4.16
+jaxlib==0.4.16
+ml-dtypes==0.4.0
+numpy==1.26.4
+opt-einsum==3.3.0
+packaging==24.0
+pluggy==1.5.0
+pytest==8.2.0
+scipy==1.13.0

--- a/jax/issue_18004/test_issue_18004.py
+++ b/jax/issue_18004/test_issue_18004.py
@@ -1,0 +1,27 @@
+import jax
+import jax.numpy as jnp
+import pytest
+
+def scalar_add(x, y):
+  # emphasize that only scalar tracers will be passed to this function.
+  assert jnp.shape(x) == jnp.shape(y) == ()
+  return x + y
+
+def f():
+  add = jnp.frompyfunc(scalar_add, nin=2, nout=1, identity=0)
+
+  x = jnp.ones((5, 3))
+  indices = jnp.array([0,4,2])
+  t = jnp.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+
+  x = add.at(x, indices, t, inplace=False)
+  # ValueError: safe_zip() argument 2 is shorter than argument 1
+
+def test_f():
+  issue_no = '18004'
+  print('Jax issue no.', issue_no)
+  jax.print_environment_info()
+
+  with pytest.raises(ValueError) as e_info:
+    f()
+  print(e_info)


### PR DESCRIPTION
Closes: #28

Logs:
```
=================================================================================== test session starts ===================================================================================
platform linux -- Python 3.11.0, pytest-8.2.0, pluggy-1.5.0
rootdir: /home/amanks/dnnbugs/jax/issue_18004
collected 1 item                                                                                                                                                                          

test_issue_18004.py Jax issue no. 18004
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1715293684.150432    6467 tfrt_cpu_pjrt_client.cc:349] TfrtCpuClient created.
jax:    0.4.16
jaxlib: 0.4.16
numpy:  1.26.4
python: 3.11.0 (main, Mar  1 2023, 18:26:19) [GCC 11.2.0]
jax.devices (1 total, 1 local): [CpuDevice(id=0)]
process_count: 1
<ExceptionInfo ValueError('safe_zip() argument 2 is shorter than argument 1') tblen=6>
.

==================================================================================== 1 passed in 0.33s ====================================================================================
```