### PR TITLE
Added bug from issue no. 17922 - jax

### DIFF
--- a/bug_dataset_jax.csv
+++ b/bug_dataset_jax.csv
@@ -47,4 +47,4 @@ Issue #,PR #,Title,Reproduced,Issue Status,Device,API,Reported,Buggy Version,Nig
 18004,18017,Issue with JAX's frompyfunc and at methods when compared to NumPy,Yes,Closed,CPU,,10/08/2023,0.4.16,No,jax/_src/numpy/ufunc_api.py,_at_via_scan(),,https://github.com/google/jax/issues/18004,https://github.com/google/jax/pull/18017
 17972,,lax.clz and lax.population_count are not documented,No,Closed,,,,,,,,Skipped: related to documentation,https://github.com/google/jax/issues/17972,
 17958,,lax.abs crashes on unsigned ints,No,Closed,CPU,,,,,,,Skipped: api misuse,https://github.com/google/jax/issues/17958,
-17922,,random.dirichlet sometimes samples nan for sparse alpha,No,Closed,CPU,,,,,,,TODO,https://github.com/google/jax/issues/17922,
+17922,17925,random.dirichlet sometimes samples nan for sparse alpha,Yes,Closed,CPU,,10/04/2023,0.4.17,No,jax/_src/random.py,_gamma_one(),,https://github.com/google/jax/issues/17922,https://github.com/google/jax/pull/17925

--- a/jax/issue_17922/reproduce_bug.sh
+++ b/jax/issue_17922/reproduce_bug.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+conda init
+conda create --name issue_17922 python==3.11 pip -y
+eval "$(conda shell.bash hook)"
+conda activate issue_17922
+pip install -r requirements.txt
+pytest -sx
+returncode=$?
+conda deactivate
+conda env remove --name issue_17922 -y
+exit ${returncode}

--- a/jax/issue_17922/requirements.txt
+++ b/jax/issue_17922/requirements.txt
@@ -1,0 +1,10 @@
+iniconfig==2.0.0
+jax[cpu]==0.4.17
+jaxlib==0.4.17
+ml-dtypes==0.4.0
+numpy==1.26.4
+opt-einsum==3.3.0
+packaging==24.0
+pluggy==1.5.0
+pytest==8.2.0
+scipy==1.13.0

--- a/jax/issue_17922/test_issue_17922.py
+++ b/jax/issue_17922/test_issue_17922.py
@@ -1,0 +1,13 @@
+import jax
+from jax._src.random import _gamma_one
+import jax.numpy as jnp
+
+def test_f():
+    issue_no = '17922'
+    print('Jax issue no.', issue_no)
+    jax.print_environment_info()
+
+    key=jax.random.wrap_key_data(jnp.array([1057748167, 1356978999], dtype='uint32'))
+    result=_gamma_one(key, 0.0, log_space=True)
+    print(result)
+    assert jnp.isnan(result) # Gives NaN


### PR DESCRIPTION
closes #38 

Logs:
```
=================================================================================== test session starts ===================================================================================
platform linux -- Python 3.11.0, pytest-8.2.0, pluggy-1.5.0
rootdir: /home/amanks/dnnbugs/jax/issue_17922
collected 1 item                                                                                                                                                                          

test_issue_17922.py Jax issue no. 17922
jax:    0.4.17
jaxlib: 0.4.17
numpy:  1.26.4
python: 3.11.0 (main, Mar  1 2023, 18:26:19) [GCC 11.2.0]
jax.devices (1 total, 1 local): [CpuDevice(id=0)]
process_count: 1
nan
.

==================================================================================== 1 passed in 0.81s ====================================================================================
```