### PR TITLE
Added bug from issue no. 17761 - jax

### DIFF
--- a/bug_dataset_jax.csv
+++ b/bug_dataset_jax.csv
@@ -48,5 +48,6 @@ Issue #,PR #,Title,Reproduced,Issue Status,Device,API,Reported,Buggy Version,Nig
 17972,,lax.clz and lax.population_count are not documented,No,Closed,,,,,,,,Skipped: related to documentation,https://github.com/google/jax/issues/17972,
 17958,,lax.abs crashes on unsigned ints,No,Closed,CPU,,,,,,,Skipped: api misuse,https://github.com/google/jax/issues/17958,
 17922,17925,random.dirichlet sometimes samples nan for sparse alpha,Yes,Closed,CPU,,10/04/2023,0.4.17,No,jax/_src/random.py,_gamma_one(),,https://github.com/google/jax/issues/17922,https://github.com/google/jax/pull/17925
+17761,17766,jax.random.key(0).itemsize crashes,Yes,Closed,CPU,,09/25/2023,0.4.16,No,jax/_src/prng.py,itemsize(),Not Implemented Error,,https://github.com/google/jax/issues/17761,https://github.com/google/jax/pull/17766
 17758,17768,jax.random.wrap_key_data(impl=key.impl) problems,Yes,Closed,CPU	,,09/25/2023,0.4.17,No,jax/_src/random.py,wrap_key_data() resolve_prng_impl(),Implementation Error,https://github.com/google/jax/issues/17758,https://github.com/google/jax/pull/17768
 17702,17721,jnp.asarray making copies in latest jax,Yes,Closed,CPU,,09/21/2023,0.4.16,No,Force PUSHED,Force Pushed,Memory Error,https://github.com/google/jax/issues/17702,https://github.com/google/jax/pull/17721

--- a/jax/issue_17761/reproduce_bug.sh
+++ b/jax/issue_17761/reproduce_bug.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+conda init
+conda create --name issue_17761 python==3.11 pip -y
+eval "$(conda shell.bash hook)"
+conda activate issue_17761
+pip install -r requirements.txt
+pytest -sx
+returncode=$?
+conda deactivate
+conda env remove --name issue_17761 -y
+exit ${returncode}

--- a/jax/issue_17761/requirements.txt
+++ b/jax/issue_17761/requirements.txt
@@ -1,0 +1,10 @@
+iniconfig==2.0.0
+jax[cpu]==0.4.16
+jaxlib==0.4.16
+ml-dtypes==0.4.0
+numpy==1.26.4
+opt-einsum==3.3.0
+packaging==24.0
+pluggy==1.5.0
+pytest==8.2.1
+scipy==1.13.1

--- a/jax/issue_17761/test_issue_17761.py
+++ b/jax/issue_17761/test_issue_17761.py
@@ -1,0 +1,11 @@
+import jax
+import pytest
+
+def test_f():
+    issue_no = '17761'
+    print('Jax issue no.', issue_no)
+    jax.print_environment_info()
+
+    with pytest.raises(NotImplementedError) as e_info:
+        x = jax.random.key(0).itemsize # Abstract method itemsize is Not Implemented
+    print(f'{e_info.type.__name__}: {e_info.value}')


### PR DESCRIPTION
closes #78 

Logs:
```
=================================================================================== test session starts ===================================================================================
platform linux -- Python 3.11.0, pytest-8.2.1, pluggy-1.5.0
rootdir: /home/amanks/dnnbugs/jax/issue_17761
collected 1 item                                                                                                                                                                          

test_issue_17761.py Jax issue no. 17761
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1716981326.976757    3080 tfrt_cpu_pjrt_client.cc:349] TfrtCpuClient created.
jax:    0.4.16
jaxlib: 0.4.16
numpy:  1.26.4
python: 3.11.0 (main, Mar  1 2023, 18:26:19) [GCC 11.2.0]
jax.devices (1 total, 1 local): [CpuDevice(id=0)]
process_count: 1
NotImplementedError: Cannot call abstract method itemsize
.

==================================================================================== 1 passed in 0.33s ====================================================================================
```