### PR TITLE
Added bug from issue no. 17020 - jax

### DIFF
--- a/jax/issue_17020/reproduce_bug.sh
+++ b/jax/issue_17020/reproduce_bug.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+conda init
+conda create --name issue_17020 python==3.11 pip -y
+eval "$(conda shell.bash hook)"
+conda activate issue_17020
+pip install -r requirements.txt
+pytest -sx
+returncode=$?
+conda deactivate
+conda env remove --name issue_17020 -y
+exit ${returncode}

--- a/jax/issue_17020/requirements.txt
+++ b/jax/issue_17020/requirements.txt
@@ -1,0 +1,10 @@
+iniconfig==2.0.0
+jax[cpu]==0.4.13
+jaxlib==0.4.13
+ml-dtypes==0.4.0
+numpy==1.26.4
+opt-einsum==3.3.0
+packaging==24.0
+pluggy==1.5.0
+pytest==8.2.2
+scipy==1.13.1

--- a/jax/issue_17020/test_issue_17020.py
+++ b/jax/issue_17020/test_issue_17020.py
@@ -1,0 +1,23 @@
+import jax
+import jax.numpy as jnp
+import pytest
+
+def f(x, y):
+    if y is None:
+        return x
+    return x * y
+
+f = jnp.vectorize(f, signature="(),()->()")
+
+def test_f():
+    issue_no = '17020'
+    print('Jax issue no.', issue_no)
+    jax.print_environment_info()
+
+    res1 = f(1., None)
+    print(res1)
+    assert jnp.isnan(res1) # returns NaN
+    
+    res2 = f(jnp.ones(6), None)
+    print(res2)
+    assert jnp.all(jnp.isnan(res2)) # returns array of NaNs


### PR DESCRIPTION
closes #97 

Logs:
```
=================================================================================== test session starts ===================================================================================
platform linux -- Python 3.11.0, pytest-8.2.2, pluggy-1.5.0
rootdir: /home/amanks/dnnbugs/jax/issue_17020
collected 1 item                                                                                                                                                                          

test_issue_17020.py Jax issue no. 17020
jax:    0.4.13
jaxlib: 0.4.13
numpy:  1.26.4
python: 3.11.0 (main, Mar  1 2023, 18:26:19) [GCC 11.2.0]
jax.devices (1 total, 1 local): [CpuDevice(id=0)]
process_count: 1
nan
[nan nan nan nan nan nan]
.

==================================================================================== 1 passed in 0.37s ====================================================================================
```