### PR TITLE
Added bug from issue no. 20624 - jax

### DIFF
--- a/bug_dataset_jax.csv
+++ b/bug_dataset_jax.csv
@@ -1,5 +1,6 @@
 ,Filter:,is:issue is:closed created:2023-09-01..2024-03-27 label:bug linked:pr ,Total Reproduced:,27,,,,,,,,,,,
 Issue #,PR #,Title,Reproduced,Issue Status,Device,API,Reported,Buggy Version,Nightly,Buggy File(s),Buggy Function(s),Type,Remarks,Issue Link,PR Link
+20624,20637,Tracer's imag method returns float; crashes with the Array API,Yes,Open,CPU,,08/04/2024,0.4.26,No,"jax/experimental/array_api/_data_type_functions.py, jax/experimental/array_api/_elementwise_functions.py","result_type(), _promote_dtypes()",Attribute Error,,https://github.com/google/jax/issues/20624,https://github.com/google/jax/pull/20637
 20455,,Install failed when using pip for JAX and CUDA,No,Closed,,,,,,,,,Skipped: related to installation,https://github.com/google/jax/issues/20455,
 20453,,Error: 'apple_common' value has no field or method 'multi_arch_split',No,Closed,,,,,,,,,Skipped: related to building,https://github.com/google/jax/issues/20453,
 20430,20528,jax.scipy.special.ndtri edge case behavior,Yes,Closed,CPU,,03/26/2024,0.4.23,No,jax/_src/scipy/special.py,_ndtri(),Incorrect output,,https://github.com/google/jax/issues/20430,https://github.com/google/jax/pull/20528

--- a/jax/issue_20624/reproduce_bug.sh
+++ b/jax/issue_20624/reproduce_bug.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+conda init
+conda create --name issue_20624 python==3.11 pip -y
+eval "$(conda shell.bash hook)"
+conda activate issue_20624
+pip install -r requirements.txt
+pytest -sx
+returncode=$?
+conda deactivate
+conda env remove --name issue_20624 -y
+exit ${returncode}

--- a/jax/issue_20624/requirements.txt
+++ b/jax/issue_20624/requirements.txt
@@ -1,0 +1,10 @@
+iniconfig==2.0.0
+jax[cpu]==0.4.26
+jaxlib==0.4.26
+ml-dtypes==0.4.0
+numpy==1.26.4
+opt-einsum==3.3.0
+packaging==24.1
+pluggy==1.5.0
+pytest==8.2.2
+scipy==1.13.1

--- a/jax/issue_20624/test_issue_20624.py
+++ b/jax/issue_20624/test_issue_20624.py
@@ -1,0 +1,17 @@
+import jax
+import jax.numpy as jnp
+from jax import jit
+import pytest
+
+@jit
+def f(x):
+    x.imag.shape
+
+def test_f():
+    issue_no = '20624'
+    print('Jax issue no.', issue_no)
+    jax.print_environment_info()
+
+    with pytest.raises(AttributeError) as e_info:
+        f(jnp.asarray(0.0)) # AttributeError as x.imag is a float object, so it doesn't have the attribute shape.
+    print(f'{e_info.type.__name__}: {e_info.value}')


### PR DESCRIPTION
closes #108 

Logs:
```
=================================================================================== test session starts ===================================================================================
platform linux -- Python 3.11.0, pytest-8.2.2, pluggy-1.5.0
rootdir: /home/amanks/dnnbugs/jax/issue_20624
collected 1 item                                                                                                                                                                          

test_issue_20624.py Jax issue no. 20624
jax:    0.4.26
jaxlib: 0.4.26
numpy:  1.26.4
python: 3.11.0 (main, Mar  1 2023, 18:26:19) [GCC 11.2.0]
jax.devices (1 total, 1 local): [CpuDevice(id=0)]
process_count: 1
platform: uname_result(system='Linux', node='fedoravm', release='6.8.10-300.fc40.x86_64', version='#1 SMP PREEMPT_DYNAMIC Fri May 17 21:20:54 UTC 2024', machine='x86_64')

AttributeError: 'float' object has no attribute 'shape'
.

==================================================================================== 1 passed in 0.31s ====================================================================================
```