### PR TITLE
Added bug from issue no. 20856 - jax

### DIFF
--- a/bug_dataset_jax.csv
+++ b/bug_dataset_jax.csv
@@ -1,5 +1,6 @@
 ,Filter:,is:issue is:closed created:2023-09-01..2024-03-27 label:bug linked:pr ,Total Reproduced:,27,,,,,,,,,,,
 Issue #,PR #,Title,Reproduced,Issue Status,Device,API,Reported,Buggy Version,Nightly,Buggy File(s),Buggy Function(s),Type,Remarks,Issue Link,PR Link
+20856,,jax.nn.softmax is inconsistent under jax.jit,Yes,Open,CPU,,04/21/2024,0.4.26,No,,,Incorrect output,No PR found,https://github.com/google/jax/issues/20856,
 20624,20637,Tracer's imag method returns float; crashes with the Array API,Yes,Open,CPU,,08/04/2024,0.4.26,No,"jax/experimental/array_api/_data_type_functions.py, jax/experimental/array_api/_elementwise_functions.py","result_type(), _promote_dtypes()",Attribute Error,,https://github.com/google/jax/issues/20624,https://github.com/google/jax/pull/20637
 20455,,Install failed when using pip for JAX and CUDA,No,Closed,,,,,,,,,Skipped: related to installation,https://github.com/google/jax/issues/20455,
 20453,,Error: 'apple_common' value has no field or method 'multi_arch_split',No,Closed,,,,,,,,,Skipped: related to building,https://github.com/google/jax/issues/20453,

--- a/jax/issue_20856/reproduce_bug.sh
+++ b/jax/issue_20856/reproduce_bug.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+conda init
+conda create --name issue_20856 python==3.9 pip -y
+eval "$(conda shell.bash hook)"
+conda activate issue_20856
+pip install -r requirements.txt
+pytest -sx
+returncode=$?
+conda deactivate
+conda env remove --name issue_20856 -y
+exit ${returncode}

--- a/jax/issue_20856/requirements.txt
+++ b/jax/issue_20856/requirements.txt
@@ -1,0 +1,14 @@
+exceptiongroup==1.2.1
+importlib_metadata==7.2.1
+iniconfig==2.0.0
+jax[cpu]==0.4.26
+jaxlib==0.4.26
+ml-dtypes==0.4.0
+numpy==2.0.0
+opt-einsum==3.3.0
+packaging==24.1
+pluggy==1.5.0
+pytest==8.2.2
+scipy==1.13.1
+tomli==2.0.1
+zipp==3.19.2

--- a/jax/issue_20856/test_issue_20856.py
+++ b/jax/issue_20856/test_issue_20856.py
@@ -1,0 +1,18 @@
+import jax
+import jax.numpy as jnp
+import pytest
+
+def f(x):
+    return jax.nn.softmax(x, axis=0)
+
+def test_f():
+    issue_no = '20856'
+    print('Jax issue no.', issue_no)
+    jax.print_environment_info()
+
+    x = jax.random.normal(jax.random.key(0), (3, 1, 1))
+    y1 = f(x)
+    y2 = jax.jit(f)(x)
+    print(y1, y2, sep="\n")
+
+    assert not jnp.allclose(y1, y2) # Output y1 and y2 do not match, due to inconsistency in function jax.nn.softmax


### PR DESCRIPTION
closes #114 

Logs:
```
=================================================================================== test session starts ===================================================================================
platform linux -- Python 3.9.0, pytest-8.2.2, pluggy-1.5.0
rootdir: /home/amanks/dnnbugs/jax/issue_20856
collected 1 item                                                                                                                                                                          

test_issue_20856.py Jax issue no. 20856
jax:    0.4.26
jaxlib: 0.4.26
numpy:  2.0.0
python: 3.9.0 (default, Nov 15 2020, 14:28:56)  [GCC 7.3.0]
jax.devices (1 total, 1 local): [CpuDevice(id=0)]
process_count: 1
platform: uname_result(system='Linux', node='fedoravm', release='6.8.10-300.fc40.x86_64', version='#1 SMP PREEMPT_DYNAMIC Fri May 17 21:20:54 UTC 2024', machine='x86_64')

[[[0.75250584]]

 [[0.0755428 ]]

 [[0.17195134]]]
[[[1.]]

 [[1.]]

 [[1.]]]
.

==================================================================================== 1 passed in 0.50s ====================================================================================
```