### PR TITLE
Added bug from issue no. 17199 - jax

### DIFF
--- a/jax/issue_17199/reproduce_bug.sh
+++ b/jax/issue_17199/reproduce_bug.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+conda init
+conda create --name issue_17199 python==3.11 pip -y
+eval "$(conda shell.bash hook)"
+conda activate issue_17199
+pip install -r requirements.txt
+pytest -sx
+returncode=$?
+conda deactivate
+conda env remove --name issue_17199 -y
+exit ${returncode}

--- a/jax/issue_17199/requirements.txt
+++ b/jax/issue_17199/requirements.txt
@@ -1,0 +1,10 @@
+iniconfig==2.0.0
+jax==0.4.14
+jaxlib==0.4.14
+ml-dtypes==0.4.0
+numpy==1.26.4
+opt-einsum==3.3.0
+packaging==24.1
+pluggy==1.5.0
+pytest==8.2.2
+scipy==1.12.0

--- a/jax/issue_17199/test_issue_17199.py
+++ b/jax/issue_17199/test_issue_17199.py
@@ -1,0 +1,17 @@
+import jax
+from jax.scipy import stats as jstats
+from scipy import stats
+import numpy as np
+import pytest
+
+def test_f():
+    issue_no = '17199'
+    print('Jax issue no.', issue_no)
+    jax.print_environment_info()
+
+    value = np.array(10, np.float32)
+    res_scipy = stats.norm.sf(value)
+    res_jax = jstats.norm.sf(value)
+
+    print('scipy:', res_scipy)
+    print('jax:', res_jax) # jax.scipy.stats.norm.sf is not accurate


### PR DESCRIPTION
closes #94 

Logs:
```
=================================================================================== test session starts ===================================================================================
platform linux -- Python 3.11.0, pytest-8.2.2, pluggy-1.5.0
rootdir: /home/amanks/dnnbugs/jax/issue_17199
collected 1 item                                                                                                                                                                          

test_issue_17199.py Jax issue no. 17199
jax:    0.4.14
jaxlib: 0.4.14
numpy:  1.26.4
python: 3.11.0 (main, Mar  1 2023, 18:26:19) [GCC 11.2.0]
jax.devices (1 total, 1 local): [CpuDevice(id=0)]
process_count: 1
scipy: 7.61985302416047e-24
jax: 0.0
.

==================================================================================== 1 passed in 0.64s ====================================================================================
```