### PR TITLE
Added bug from issue no. 22305 - jax

### DIFF
--- a/jax/issue_22305/reproduce_bug.sh
+++ b/jax/issue_22305/reproduce_bug.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+conda init
+conda create --name issue_22305 python==3.11 pip -y
+eval "$(conda shell.bash hook)"
+conda activate issue_22305
+pip install -r requirements.txt
+pytest -sx
+returncode=$?
+conda deactivate
+conda env remove --name issue_22305 -y
+exit ${returncode}

--- a/jax/issue_22305/requirements.txt
+++ b/jax/issue_22305/requirements.txt
@@ -1,0 +1,10 @@
+iniconfig==2.0.0
+jax @ https://storage.googleapis.com/jax-releases/nightly/jax/jax-0.4.31.dev20240707-py3-none-any.whl#sha256=ec1670cc829507dc1226ca7ec7b8ef1b4c90a6c0f3e9d480e302116bc0bd3fff
+jaxlib @ https://storage.googleapis.com/jax-releases/nightly/nocuda/jaxlib-0.4.31.dev20240707-cp311-cp311-manylinux2014_x86_64.whl#sha256=4f5b17bef4044ee792eb579d1fbe292d842a90f4816d53c189f3f7ce4cb15bc1
+ml-dtypes==0.4.0
+numpy==2.0.0
+opt-einsum==3.3.0
+packaging==24.1
+pluggy==1.5.0
+pytest==8.2.2
+scipy==1.14.0

--- a/jax/issue_22305/test_issue_22305.py
+++ b/jax/issue_22305/test_issue_22305.py
@@ -1,0 +1,12 @@
+import jax
+from jax import numpy as jnp
+import pytest
+
+def test_f():
+    issue_no = '22305'
+    print('Jax issue no.', issue_no)
+    jax.print_environment_info()
+
+    with jax.numpy_rank_promotion('raise'): # does not raise ValueError on catching rank promotions inside jnp.vectorize
+        my_sum = jnp.vectorize(lambda x, y: x + y, signature='(n),(n)->(n)')
+        my_sum(jnp.zeros((10, 10)), jnp.zeros((10,)))


### PR DESCRIPTION
Closes #131 

Logs:
```
=================================================================================== test session starts ===================================================================================
platform linux -- Python 3.11.0, pytest-8.2.2, pluggy-1.5.0
rootdir: /home/amanks/dnnbugs/jax/issue_22305
collected 1 item                                                                                                                                                                          

test_issue_22305.py Jax issue no. 22305
jax:    0.4.31.dev20240707
jaxlib: 0.4.31.dev20240707
numpy:  2.0.0
python: 3.11.0 (main, Mar  1 2023, 18:26:19) [GCC 11.2.0]
jax.devices (1 total, 1 local): [CpuDevice(id=0)]
process_count: 1
platform: uname_result(system='Linux', node='fedoravm', release='6.9.5-200.fc40.x86_64', version='#1 SMP PREEMPT_DYNAMIC Sun Jun 16 15:47:09 UTC 2024', machine='x86_64')

.

==================================================================================== 1 passed in 0.37s ====================================================================================
```