### PR TITLE
Added bug from issue no. 129742 - pytorch

### DIFF
--- a/bug_dataset_pytorch.csv
+++ b/bug_dataset_pytorch.csv
@@ -21,7 +21,6 @@ Issue #,PR #,Title,Reproduced,Issue Status,Device,API,Reported,Buggy Version,Nig
 130087,,Calling id function on model param causes error or graph break for compile,No,Closed,,,,,,,,,For 712,https://github.com/pytorch/pytorch/issues/130087,
 129927,,Error when exporting a module without input,No,Closed,,,,,,,,,For 712,https://github.com/pytorch/pytorch/issues/129927,
 129742,129743,hasattr tracing for torch tensor is unsupported,Yes,Closed,CPU,,06/28/2024,2.3.1,No,torch/_dynamo/variables/tensor.py,call_hasattr(),Internal Exception,,https://github.com/pytorch/pytorch/issues/129742,https://github.com/pytorch/pytorch/pull/129743
-129742,,hasattr tracing for torch tensor is unsupported,No,Closed,,,,,,,,,For 712,https://github.com/pytorch/pytorch/issues/129742,
 128557,,MaskedTensor do not support _is_any_true`,No,Closed,,,,,,,,,For 712,https://github.com/pytorch/pytorch/issues/128557,
 128429,,"taking upper triangular of ""-inf"" matrix results in nan values",No,Closed,,,,,,,,,For 712,https://github.com/pytorch/pytorch/issues/128429,
 128202,,Wrong result for Inplace tensor update on transpose for some devices with torch 2.3.0,No,Closed,,,,,,,,,For 712,https://github.com/pytorch/pytorch/issues/128202,

--- a/pytorch/issue_129742/reproduce_bug.sh
+++ b/pytorch/issue_129742/reproduce_bug.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+conda init
+conda create --name issue_129742 python==3.10 pip -y
+eval "$(conda shell.bash hook)"
+conda activate issue_129742
+pip install -r  requirements.txt
+if [[ $OSTYPE == 'darwin'* ]]
+then
+    brew install libomp
+fi
+python -m torch.utils.collect_env
+pytest -sx
+returncode=$?
+conda deactivate
+conda env remove --name issue_129742 -y
+exit ${returncode}

--- a/pytorch/issue_129742/requirements.txt
+++ b/pytorch/issue_129742/requirements.txt
@@ -1,0 +1,20 @@
+exceptiongroup==1.2.2
+filelock==3.13.1
+fsspec==2024.2.0
+iniconfig==2.0.0
+Jinja2==3.1.3
+MarkupSafe==2.1.5
+mpmath==1.3.0
+networkx==3.2.1
+numpy==1.26.3
+packaging==24.1
+pillow==10.2.0
+pluggy==1.5.0
+pytest==8.3.2
+sympy==1.12
+tomli==2.0.1
+--extra-index-url https://download.pytorch.org/whl/cpu
+torch==2.3.1+cpu
+torchaudio==2.3.1+cpu
+torchvision==0.18.1+cpu
+typing_extensions==4.9.0

--- a/pytorch/issue_129742/test_issue_129742.py
+++ b/pytorch/issue_129742/test_issue_129742.py
@@ -1,0 +1,20 @@
+import torch
+import pytest
+
+# using fullgraph to raise an exception in place of graph breaks
+@torch.compile(backend='inductor', fullgraph=True) 
+def f(x):
+    if hasattr(x, "attr"):
+        return x + 1
+    else:
+        return x - 1
+
+def test_f():
+    issue_no = '129742'
+    print('Pytorch issue no.', issue_no)
+
+    t1 = torch.tensor([6.])
+    t1.attr = False
+    with pytest.raises(torch._dynamo.exc.Unsupported) as e_info:
+        f(t1)
+    print(f'{e_info.type.__name__}: {e_info.value}')


### PR DESCRIPTION
Closes: #151 

Logs:
```
=================================================================================== test session starts ====================================================================================
platform linux -- Python 3.10.0, pytest-8.3.2, pluggy-1.5.0
rootdir: /home/amanks/dnnbugs/pytorch/issue_129742
collected 1 item                                                                                                                                                                           

test_issue_129742.py Pytorch issue no. 129742
Unsupported: hasattr TensorVariable attr

from user code:
   File "/home/amanks/dnnbugs/pytorch/issue_129742/test_issue_129742.py", line 7, in f
    if hasattr(x, "attr"):

Set TORCH_LOGS="+dynamo" and TORCHDYNAMO_VERBOSE=1 for more information


You can suppress this exception and fall back to eager by setting:
    import torch._dynamo
    torch._dynamo.config.suppress_errors = True

.

==================================================================================== 1 passed in 1.54s =====================================================================================

```