### PR TITLE
Added bug from issue no. 120387 - pytorch

### DIFF
--- a/bug_dataset_pytorch.csv
+++ b/bug_dataset_pytorch.csv
@@ -1,6 +1,7 @@
 ,Filter:,is:issue is:closed created:2024-02-25..2024-03-27 linked:pr ,Total Reproduced:,23,,,,,,,,,,,
 Issue #,PR #,Title,Reproduced,Issue Status,Device,API,Reported,Buggy Version,Nightly,Buggy File(s),Buggy Function(s),Type,Remarks,Issue Link,PR Link
 120188,120136,[aot autograd] partitioner error when an input is mutated inplace and another input is a tensor subclass,Yes,Closed,CPU,,02/19/2024,2.3.0.dev20240215,Yes,torch/_functorch/_aot_autograd/collect_metadata_analysis.py,"inner(), view_avoid_dupes_with_primals()",Assertion Error,,https://github.com/pytorch/pytorch/issues/120188,https://github.com/pytorch/pytorch/pull/120136
+120387,120390,Dynamo guard failure if calling torch.jit.script_if_tracing wrapped function with default arguments,Yes,Closed,CPU,,02/22/2024,2.2.0,No,torch/_dynamo/utils.py,"unwrap_if_wrapper(), unwrap_with_attr_name_if_wrapper()",Internal Exception,,https://github.com/pytorch/pytorch/issues/120387,https://github.com/pytorch/pytorch/pull/120390
 122594,,There is a comment error in test_transformers.py,No,Closed,,,,,,,,,Skipped: not a bug,https://github.com/pytorch/pytorch/issues/122594,
 122521,,UserWarning when using Tensor Model Parallel libraries (megatron and fairscale),No,Closed,,,,,,,,,"Skipped: bug describes a warning, not an exception",https://github.com/pytorch/pytorch/issues/122521,
 122445,,allow storage to be created for ort,No,Closed,,,,,,,,,Skipped: not a bug,https://github.com/pytorch/pytorch/issues/122445,

--- a/pytorch/issue_120387/reproduce_bug.sh
+++ b/pytorch/issue_120387/reproduce_bug.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+conda init
+conda create --name issue_120387 python==3.10 pip -y
+eval "$(conda shell.bash hook)"
+conda activate issue_120387
+pip install -r  requirements.txt
+if [[ $OSTYPE == 'darwin'* ]]
+then
+    brew install libomp
+fi
+python -m torch.utils.collect_env
+pytest -sx
+returncode=$?
+conda deactivate
+conda env remove --name issue_120387 -y
+exit ${returncode}

--- a/pytorch/issue_120387/requirements.txt
+++ b/pytorch/issue_120387/requirements.txt
@@ -1,0 +1,25 @@
+certifi==2022.12.7
+charset-normalizer==2.1.1
+exceptiongroup==1.2.2
+filelock==3.13.1
+fsspec==2024.2.0
+idna==3.4
+iniconfig==2.0.0
+Jinja2==3.1.3
+MarkupSafe==2.1.5
+mpmath==1.3.0
+networkx==3.2.1
+numpy==1.26.3
+packaging==24.1
+pillow==10.2.0
+pluggy==1.5.0
+pytest==8.3.2
+requests==2.28.1
+sympy==1.12
+tomli==2.0.1
+--extra-index-url https://download.pytorch.org/whl/cpu
+torch==2.2.0+cpu
+torchaudio==2.2.0+cpu
+torchvision==0.17.0+cpu
+typing_extensions==4.9.0
+urllib3==1.26.13

--- a/pytorch/issue_120387/test_issue_120387.py
+++ b/pytorch/issue_120387/test_issue_120387.py
@@ -1,0 +1,19 @@
+import torch
+import pytest
+
+@torch.jit.script_if_tracing
+def g(x, y, _ = None):
+    return torch.cos(x * y)
+
+@torch.compile(backend="eager")
+def f(x, z):
+    return g(x, 2, z)
+
+def test_f():
+    issue_no = '120387'
+    print('Pytorch issue no.', issue_no)
+
+    with pytest.raises(torch._dynamo.exc.InternalTorchDynamoError) as e_info:
+        print(f(torch.randn(4), 1))
+        print(f(torch.randn(4), torch.randn(4)))
+    print(f'{e_info.type.__name__}: {e_info.value}')


### PR DESCRIPTION
Closes: #148 

Logs:
```
=================================================================================== test session starts ====================================================================================
platform linux -- Python 3.10.0, pytest-8.3.2, pluggy-1.5.0
rootdir: /home/amanks/dnnbugs/pytorch/issue_120387
collected 1 item                                                                                                                                                                           

test_issue_120387.py Pytorch issue no. 120387
[2024-09-09 18:04:16,602] [0/0] torch._guards: [ERROR] Error while creating guard:
[2024-09-09 18:04:16,602] [0/0] torch._guards: [ERROR] Name: "G['g'].__defaults__[0]"
[2024-09-09 18:04:16,602] [0/0] torch._guards: [ERROR]     Source: global
[2024-09-09 18:04:16,602] [0/0] torch._guards: [ERROR]     Create Function: CONSTANT_MATCH
[2024-09-09 18:04:16,602] [0/0] torch._guards: [ERROR]     Guard Types: None
[2024-09-09 18:04:16,602] [0/0] torch._guards: [ERROR]     Code List: None
[2024-09-09 18:04:16,602] [0/0] torch._guards: [ERROR]     Object Weakref: None
[2024-09-09 18:04:16,602] [0/0] torch._guards: [ERROR]     Guarded Class Weakref: None
[2024-09-09 18:04:16,603] [0/0] torch._guards: [ERROR] Created at:
[2024-09-09 18:04:16,603] [0/0] torch._guards: [ERROR]   File "/home/amanks/miniconda3/envs/issue_120387/lib/python3.10/site-packages/torch/_dynamo/variables/functions.py", line 28, in wrap_bound_arg
[2024-09-09 18:04:16,603] [0/0] torch._guards: [ERROR]     return VariableBuilder(tx, source=source)(val)
[2024-09-09 18:04:16,603] [0/0] torch._guards: [ERROR]   File "/home/amanks/miniconda3/envs/issue_120387/lib/python3.10/site-packages/torch/_dynamo/variables/builder.py", line 245, in __call__
[2024-09-09 18:04:16,603] [0/0] torch._guards: [ERROR]     vt = self._wrap(value).clone(**self.options())
[2024-09-09 18:04:16,603] [0/0] torch._guards: [ERROR]   File "/home/amanks/miniconda3/envs/issue_120387/lib/python3.10/site-packages/torch/_dynamo/variables/builder.py", line 386, in _wrap
[2024-09-09 18:04:16,603] [0/0] torch._guards: [ERROR]     return type_dispatch(self, value)
[2024-09-09 18:04:16,603] [0/0] torch._guards: [ERROR]   File "/home/amanks/miniconda3/envs/issue_120387/lib/python3.10/site-packages/torch/_dynamo/variables/builder.py", line 971, in wrap_literal
[2024-09-09 18:04:16,603] [0/0] torch._guards: [ERROR]     self.install_guards(GuardBuilder.CONSTANT_MATCH)
InternalTorchDynamoError: 'NoneType' object is not subscriptable


You can suppress this exception and fall back to eager by setting:
    import torch._dynamo
    torch._dynamo.config.suppress_errors = True

.

==================================================================================== 1 passed in 1.38s =====================================================================================
```