### PR TITLE
Added bug from issue no. 120188 - pytorch

### DIFF
--- a/bug_dataset_pytorch.csv
+++ b/bug_dataset_pytorch.csv
@@ -1,5 +1,6 @@
 ,Filter:,is:issue is:closed created:2024-02-25..2024-03-27 linked:pr ,Total Reproduced:,23,,,,,,,,,,,
 Issue #,PR #,Title,Reproduced,Issue Status,Device,API,Reported,Buggy Version,Nightly,Buggy File(s),Buggy Function(s),Type,Remarks,Issue Link,PR Link
+120188,120136,[aot autograd] partitioner error when an input is mutated inplace and another input is a tensor subclass,Yes,Closed,CPU,,02/19/2024,2.3.0.dev20240215,Yes,torch/_functorch/_aot_autograd/collect_metadata_analysis.py,"inner(), view_avoid_dupes_with_primals()",Assertion Error,,https://github.com/pytorch/pytorch/issues/120188,https://github.com/pytorch/pytorch/pull/120136
 122594,,There is a comment error in test_transformers.py,No,Closed,,,,,,,,,Skipped: not a bug,https://github.com/pytorch/pytorch/issues/122594,
 122521,,UserWarning when using Tensor Model Parallel libraries (megatron and fairscale),No,Closed,,,,,,,,,"Skipped: bug describes a warning, not an exception",https://github.com/pytorch/pytorch/issues/122521,
 122445,,allow storage to be created for ort,No,Closed,,,,,,,,,Skipped: not a bug,https://github.com/pytorch/pytorch/issues/122445,

--- a/pytorch/issue_120188/reproduce_bug.sh
+++ b/pytorch/issue_120188/reproduce_bug.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+conda init
+conda create --name issue_120188 python==3.10 pip -y
+eval "$(conda shell.bash hook)"
+conda activate issue_120188
+pip install -r  requirements.txt
+if [[ $OSTYPE == 'darwin'* ]]
+then
+    brew install libomp
+fi
+python -m torch.utils.collect_env
+pytest -sx
+returncode=$?
+conda deactivate
+conda env remove --name issue_120188 -y
+exit ${returncode}

--- a/pytorch/issue_120188/requirements.txt
+++ b/pytorch/issue_120188/requirements.txt
@@ -1,0 +1,16 @@
+exceptiongroup==1.2.2
+filelock==3.16.0
+fsspec==2024.9.0
+iniconfig==2.0.0
+Jinja2==3.1.4
+MarkupSafe==2.1.5
+mpmath==1.3.0
+networkx==3.3
+numpy==1.26.4
+packaging==24.1
+pluggy==1.5.0
+pytest==8.3.2
+sympy==1.13.2
+tomli==2.0.1
+torch @ https://download.pytorch.org/whl/nightly/cpu/torch-2.3.0.dev20240215%2Bcpu-cp310-cp310-linux_x86_64.whl#sha256=eb9e135b50097de39fe070ff9b57e37f85fb74000107ff3657f9ec7fde662517
+typing_extensions==4.12.2

--- a/pytorch/issue_120188/test_issue_120188.py
+++ b/pytorch/issue_120188/test_issue_120188.py
@@ -1,0 +1,27 @@
+import torch
+from torch.nested._internal.nested_tensor import jagged_from_list
+import pytest
+
+def f(x, y):
+    z = x.sin()
+    y.sin_()
+    return z.cos(), y.cos()
+
+def test_f():
+    issue_no = '120188'
+    print('Pytorch issue no.', issue_no)
+
+    f_c = torch.compile(f, backend="inductor")
+
+    values = [torch.rand((i, 8), requires_grad=True) for i in range(1, 6)]
+    values_copy = [x.detach().clone().requires_grad_(True) for x in values]
+
+    nt, offsets = jagged_from_list(values, None)
+    nt_copy, offsets = jagged_from_list(values_copy, offsets)
+    y = torch.rand((4, 8))
+    y_copy = y.clone()
+    
+    with pytest.raises(torch._dynamo.exc.BackendCompilerFailed) as e_info:
+        ret = f_c(nt, y)[0]
+        ref = f(nt_copy, y_copy)[0]
+    print(f'{e_info.type.__name__}: {e_info.value}')


### PR DESCRIPTION
Closes: #147 

Logs:
```
=================================================================================== test session starts ====================================================================================
platform linux -- Python 3.10.0, pytest-8.3.2, pluggy-1.5.0
rootdir: /home/amanks/dnnbugs/pytorch/issue_120188
collected 1 item                                                                                                                                                                           

test_issue_120188.py Pytorch issue no. 120188
BackendCompilerFailed: backend='inductor' raised:
AssertionError: Node mul_1 was invalid, but is output

Set TORCH_LOGS="+dynamo" and TORCHDYNAMO_VERBOSE=1 for more information


You can suppress this exception and fall back to eager by setting:
    import torch._dynamo
    torch._dynamo.config.suppress_errors = True

.

==================================================================================== 1 passed in 1.87s =====================================================================================
```