### PR TITLE
Added bug from issue no. 118231 - pytorch

### DIFF
--- a/bug_dataset_pytorch.csv
+++ b/bug_dataset_pytorch.csv
@@ -130,6 +130,6 @@ Issue #,PR #,Title,Reproduced,Issue Status,Device,API,Reported,Buggy Version,Nig
 118476,,logging errors for toy model with TORCH_COMPILE_DEBUG,No,Closed,,,,,,,,,For 712,https://github.com/pytorch/pytorch/issues/118476,
 118399,,Dynamo x autograd.Function: stride accesses in backward should cause graph break,No,Closed,,,,,,,,,For 712,https://github.com/pytorch/pytorch/issues/118399,
 118273,,“TypeError” triggered by unused “device” argument in torch.frombuffer(),No,Closed,,,,,,,,,For 712,https://github.com/pytorch/pytorch/issues/118273,
-118231,,operator.pos does not handle constant inputs but only tensor inputs.,No,Closed,,,,,,,,,TODO,https://github.com/pytorch/pytorch/issues/118231,
+118231,118251,operator.pos does not handle constant inputs but only tensor inputs.,Yes,Closed,CPU,,01/25/2024,2.1.2,No,torch/_dynamo/variables/builtin.py,call_pos(),Internal Exception,,https://github.com/pytorch/pytorch/issues/118231,https://github.com/pytorch/pytorch/pull/118251
 118131,,torch.addmm behavior discrepancy between CPU and GPU,No,Closed,GPU,CUDA,,,,,,,TODO,https://github.com/pytorch/pytorch/issues/118131,
 117757,,Wrong result when operator.abs is is called after abs,No,Closed,CPU,,,,,,,,TODO,https://github.com/pytorch/pytorch/issues/117757,

--- a/pytorch/issue_118231/reproduce_bug.sh
+++ b/pytorch/issue_118231/reproduce_bug.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+conda init
+conda create --name issue_118231 python==3.10 pip -y
+eval "$(conda shell.bash hook)"
+conda activate issue_118231
+pip install -r  requirements.txt
+if [[ $OSTYPE == 'darwin'* ]]
+then
+    brew install libomp
+fi
+python -m torch.utils.collect_env
+pytest -sx
+returncode=$?
+conda deactivate
+conda env remove --name issue_118231 -y
+exit ${returncode}

--- a/pytorch/issue_118231/requirements.txt
+++ b/pytorch/issue_118231/requirements.txt
@@ -1,0 +1,25 @@
+certifi==2022.12.7
+charset-normalizer==2.1.1
+exceptiongroup==1.2.2
+filelock==3.13.1
+fsspec==2024.2.0
+idna==3.4
+iniconfig==2.0.0
+Jinja2==3.1.3
+MarkupSafe==2.1.5
+mpmath==1.3.0
+networkx==3.2.1
+numpy==1.26.3
+packaging==24.1
+pillow==10.2.0
+pluggy==1.5.0
+pytest==8.3.3
+requests==2.28.1
+sympy==1.12
+tomli==2.0.1
+--extra-index-url https://download.pytorch.org/whl/cpu
+torch==2.1.2+cpu
+torchaudio==2.1.2+cpu
+torchvision==0.16.2+cpu
+typing_extensions==4.9.0
+urllib3==1.26.13

--- a/pytorch/issue_118231/test_issue_118231.py
+++ b/pytorch/issue_118231/test_issue_118231.py
@@ -1,0 +1,25 @@
+import torch
+import operator
+import unittest
+import pytest
+
+class TestUnaryFunctions(unittest.TestCase):
+    def test_unary_functions(self):
+        issue_no = '118231'
+        print('Pytorch issue no.', issue_no)
+
+        for op in (operator.pos,):
+            with self.subTest(op=op):
+                def fn(x, y):
+                    return x * op(y)
+
+                opt_fn = torch.compile(fullgraph=True, dynamic=True)(fn)
+                tensor1 = torch.ones(4)
+                tensor2 = torch.ones(4)
+
+                def test(arg1, arg2):
+                    self.assertEqual(opt_fn(arg1, arg2), fn(arg1, arg2))
+                
+                with pytest.raises(torch._dynamo.exc.Unsupported) as e_info:
+                    test(-2, -2)
+                print(f'{e_info.type.__name__}: {e_info.value}')


### PR DESCRIPTION
Closes: #165 

Logs:
```
================================= test session starts ==================================
platform linux -- Python 3.10.0, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/amanks/dnnbugs/pytorch/issue_118231
collected 1 item                                                                       

test_issue_118231.py Pytorch issue no. 118231
Unsupported: call_function BuiltinVariable(pos) [SymNodeVariable()] {}

from user code:
   File "/home/amanks/dnnbugs/pytorch/issue_118231/test_issue_118231.py", line 14, in fn
    return x * op(y)

Set TORCH_LOGS="+dynamo" and TORCHDYNAMO_VERBOSE=1 for more information


You can suppress this exception and fall back to eager by setting:
    import torch._dynamo
    torch._dynamo.config.suppress_errors = True

.

================================== 1 passed in 1.20s ===================================
```