### PR TITLE
Use compiled source binaries to reproduce issues with de-indexed PyTorch nightly builds

### DIFF
--- a/pytorch/issue_120188/reproduce_bug.sh
+++ b/pytorch/issue_120188/reproduce_bug.sh
@@ -4,6 +4,8 @@ conda init
 conda create --name issue_120188 python==3.10 pip -y
 eval "$(conda shell.bash hook)"
 conda activate issue_120188
+pip install gdown==5.2.0
+gdown --fuzzy https://drive.google.com/file/d/10x74XH7VSd5JGPWSPYTwwG9S0X4jwuXC/view?usp=sharing -O /tmp/
 pip install -r  requirements.txt
 if [[ $OSTYPE == 'darwin'* ]]
 then

--- a/pytorch/issue_120188/requirements.txt
+++ b/pytorch/issue_120188/requirements.txt
@@ -12,5 +12,5 @@ pluggy==1.5.0
 pytest==8.3.2
 sympy==1.13.2
 tomli==2.0.1
-torch @ https://download.pytorch.org/whl/nightly/cpu/torch-2.3.0.dev20240215%2Bcpu-cp310-cp310-linux_x86_64.whl#sha256=eb9e135b50097de39fe070ff9b57e37f85fb74000107ff3657f9ec7fde662517
+torch @ file:///tmp/torch-2.3.0a0%2Bgit04a9a7c-cp310-cp310-linux_x86_64.whl#sha256=3d958bb74122f070b17bb70454bc8cf0af4eec1eece3ffcff656b7341336e13c
 typing_extensions==4.12.2

--- a/pytorch/issue_120647/reproduce_bug.sh
+++ b/pytorch/issue_120647/reproduce_bug.sh
@@ -4,6 +4,8 @@ conda init
 conda create --name issue_120647 python==3.10 pip -y
 eval "$(conda shell.bash hook)"
 conda activate issue_120647
+pip install gdown==5.2.0
+gdown --fuzzy https://drive.google.com/file/d/1CBJYB13yJUgz-D2_q-K7YAClkDPKqVcx/view?usp=sharing -O /tmp/
 pip install -r  requirements.txt
 if [[ $OSTYPE == 'darwin'* ]]
 then

--- a/pytorch/issue_120647/requirements.txt
+++ b/pytorch/issue_120647/requirements.txt
@@ -12,5 +12,5 @@ pluggy==1.5.0
 pytest==8.2.0
 sympy==1.12
 tomli==2.0.1
-torch @ https://download.pytorch.org/whl/nightly/cpu/torch-2.3.0.dev20240227%2Bcpu-cp310-cp310-linux_x86_64.whl#sha256=ef6831bc8e1112afb2ab622e819a1fd357abb96071c003acef87ffe8f677c523
+torch @ file:///tmp/torch-2.3.0a0%2Bgit738f032-cp310-cp310-linux_x86_64.whl#sha256=68ff22751459fbce4553ba938759b65eb8b876d37fa7319d2cd8cce9bb13df04
 typing_extensions==4.11.0

--- a/pytorch/issue_120762/reproduce_bug.sh
+++ b/pytorch/issue_120762/reproduce_bug.sh
@@ -4,6 +4,8 @@ conda init
 conda create --name issue_120762 python==3.10 pip -y
 eval "$(conda shell.bash hook)"
 conda activate issue_120762
+pip install gdown==5.2.0
+gdown --fuzzy https://drive.google.com/file/d/10qV7qc3xSDBJy_f8EWzwhsXWwjEJCHlg/view?usp=sharing -O /tmp/
 pip install -r  requirements.txt
 if [[ $OSTYPE == 'darwin'* ]]
 then

--- a/pytorch/issue_120762/requirements.txt
+++ b/pytorch/issue_120762/requirements.txt
@@ -12,5 +12,5 @@ pluggy==1.5.0
 pytest==8.2.0
 sympy==1.12
 tomli==2.0.1
-torch @ https://download.pytorch.org/whl/nightly/cpu/torch-2.3.0.dev20240228%2Bcpu-cp310-cp310-linux_x86_64.whl#sha256=94398fc5bb7f16e0f537936a56c0ad580d5a5884d927bc4b517d4d99826294e1
+torch @ file:///tmp/torch-2.3.0a0%2Bgitc019093-cp310-cp310-linux_x86_64.whl#sha256=68bb3230c4b2a992dd64e5b9bcbb1e90019c96fd672ccec519f6702ed2bf0e97
 typing_extensions==4.11.0

--- a/pytorch/issue_120803/reproduce_bug.sh
+++ b/pytorch/issue_120803/reproduce_bug.sh
@@ -9,8 +9,8 @@ conda init
 conda create --name issue_120803 python==3.8 pip -y
 eval "$(conda shell.bash hook)"
 conda activate issue_120803
-curl -OL https://download.pytorch.org/whl/nightly/cpu/torch-2.3.0.dev20240220%2Bcpu-cp38-cp38-linux_x86_64.whl
-pip install torch-2.3.0.dev20240220%2Bcpu-cp38-cp38-linux_x86_64.whl
+pip install gdown==5.2.0
+gdown --fuzzy https://drive.google.com/file/d/1ombH9bjC3S9U6UybuvmfCZoJJPHx-U_K/view?usp=sharing -O /tmp/
 pip install -r requirements.txt
 if [[ $OSTYPE == 'darwin'* ]]
 then
@@ -21,5 +21,4 @@ pytest -sx
 returncode=$?
 conda deactivate
 conda env remove --name issue_120803 -y
-rm torch-2.3.0.dev20240220%2Bcpu-cp38-cp38-linux_x86_64.whl
 exit ${returncode}

--- a/pytorch/issue_120803/requirements.txt
+++ b/pytorch/issue_120803/requirements.txt
@@ -11,4 +11,5 @@ pluggy==1.5.0
 pytest==8.2.0
 sympy==1.12
 tomli==2.0.1
+torch @ file:///tmp/torch-2.3.0a0%2Bgit8efa066-cp38-cp38-linux_x86_64.whl#sha256=7b77151be32951651c198c3e9697a9efb25ca10ef7fd5c8eac57659db2d1382b
 typing_extensions==4.11.0

--- a/pytorch/issue_121174/reproduce_bug.sh
+++ b/pytorch/issue_121174/reproduce_bug.sh
@@ -3,6 +3,8 @@ conda init
 conda create --name issue_121174 python==3.10 pip -y
 eval "$(conda shell.bash hook)"
 conda activate issue_121174
+pip install gdown==5.2.0
+gdown --fuzzy https://drive.google.com/file/d/1mQ5N7AAJH5ismHhhoJyluyMRsXFOqqSu/view?usp=sharing -O /tmp/
 pip install -r requirements.txt
 if [[ $OSTYPE == 'darwin'* ]]
 then

--- a/pytorch/issue_121174/requirements.txt
+++ b/pytorch/issue_121174/requirements.txt
@@ -12,6 +12,5 @@ pluggy==1.4.0
 pytest==8.1.1
 sympy==1.12
 tomli==2.0.1
---extra-index-url https://download.pytorch.org/whl/nightly/cpu
-torch==2.4.0.dev20240318
+torch @ file:///tmp/torch-2.4.0a0%2Bgitc823f7a-cp310-cp310-linux_x86_64.whl#sha256=70e81ed7215d7c6e4b7fb828c787af5a5da173e30a6b8b5d3b0a3ce9d8a8a2f6
 typing_extensions==4.8.0

--- a/pytorch/issue_121188/reproduce_bug.sh
+++ b/pytorch/issue_121188/reproduce_bug.sh
@@ -4,6 +4,8 @@ conda init
 conda create --name issue_121188 python==3.10 pip -y
 eval "$(conda shell.bash hook)"
 conda activate issue_121188
+pip install gdown==5.2.0
+gdown --fuzzy https://drive.google.com/file/d/1PW6DC4pVdnddtKy3YHzRBJwrRKkr7YYx/view?usp=sharing -O /tmp/
 pip install -r  requirements.txt
 if [[ $OSTYPE == 'darwin'* ]]
 then

--- a/pytorch/issue_121188/requirements.txt
+++ b/pytorch/issue_121188/requirements.txt
@@ -12,5 +12,5 @@ pluggy==1.5.0
 pytest==8.2.1
 sympy==1.12
 tomli==2.0.1
-torch @ https://download.pytorch.org/whl/nightly/cpu/torch-2.3.0.dev20240301%2Bcpu-cp310-cp310-linux_x86_64.whl#sha256=c13797d5d23c5d628cefb87dc69eb4b85e476030431890d2a12f45e5f77ef7af
+torch @ file:///tmp/torch-2.3.0a0%2Bgit4be1e6a-cp310-cp310-linux_x86_64.whl#sha256=ae6aa6ac54e9498a55a598656680e97b83d886a2ffd4687b4c0f3d8b6c68df48
 typing_extensions==4.11.0

--- a/pytorch/issue_122126/reproduce_bug.sh
+++ b/pytorch/issue_122126/reproduce_bug.sh
@@ -3,6 +3,8 @@ conda init
 conda create --name issue_122126 python==3.10 pip -y
 eval "$(conda shell.bash hook)"
 conda activate issue_122126
+pip install gdown==5.2.0
+gdown --fuzzy https://drive.google.com/file/d/1EUUsSUFMNAgEuDbZXHfvTCN2TeqA37DK/view?usp=sharing -O /tmp/
 pip install -r requirements.txt
 if [[ $OSTYPE == 'darwin'* ]]
 then

--- a/pytorch/issue_122126/requirements.txt
+++ b/pytorch/issue_122126/requirements.txt
@@ -12,6 +12,5 @@ pluggy==1.4.0
 pytest==8.1.1
 sympy==1.12
 tomli==2.0.1
---extra-index-url https://download.pytorch.org/whl/nightly/cpu
-torch==2.4.0.dev20240320
+torch @ file:///tmp/torch-2.4.0a0%2Bgit90fdee1-cp310-cp310-linux_x86_64.whl#sha256=55bca35293a4760457e6aee8cac3544389c40bcf113ceda816797352f21c5683
 typing_extensions==4.8.0

--- a/pytorch/issue_122692/reproduce_bug.sh
+++ b/pytorch/issue_122692/reproduce_bug.sh
@@ -4,6 +4,8 @@ conda init
 conda create --name issue_122692 python==3.10 pip -y
 eval "$(conda shell.bash hook)"
 conda activate issue_122692
+pip install gdown==5.2.0
+gdown --fuzzy https://drive.google.com/file/d/1_7x5lW_SeHJ5otsSd5HGOYkSgqSQt2B7/view?usp=sharing -O /tmp/
 pip install -r  requirements.txt
 if [[ $OSTYPE == 'darwin'* ]]
 then

--- a/pytorch/issue_122692/requirements.txt
+++ b/pytorch/issue_122692/requirements.txt
@@ -12,5 +12,5 @@ pluggy==1.5.0
 pytest==8.2.1
 sympy==1.12
 tomli==2.0.1
-torch @ https://download.pytorch.org/whl/nightly/cpu/torch-2.3.0.dev20240204%2Bcpu-cp310-cp310-linux_x86_64.whl#sha256=dec6f696573c5e9331f4ca64405ee75ede41cb32efddfcaddc0aad0d48e813e9
+torch @ file:///tmp/torch-2.3.0a0%2Bgit68d3fec-cp310-cp310-linux_x86_64.whl#sha256=cc741cb740b8747e79592ace46e3624fe965ee8048a0b332e1a7675f84f66f9f
 typing_extensions==4.11.0

--- a/pytorch/issue_122771/reproduce_bug.sh
+++ b/pytorch/issue_122771/reproduce_bug.sh
@@ -2,6 +2,8 @@ conda init
 conda create --name issue_122771 python=3.10 pip -y
 eval "$(conda shell.bash hook)"
 conda activate issue_122771
+pip install gdown==5.2.0
+gdown --fuzzy https://drive.google.com/file/d/1JNpkDBx28ln2mKaoCvISvLBvFWCjboHT/view?usp=sharing -O /tmp/
 pip install -r requirements.txt
 pytest -sx
 returncode=$?

--- a/pytorch/issue_122771/requirements.txt
+++ b/pytorch/issue_122771/requirements.txt
@@ -12,6 +12,5 @@ pluggy==1.5.0
 pytest==8.2.1
 sympy==1.12
 tomli==2.0.1
---extra-index-url https://download.pytorch.org/whl/nightly/cpu
-torch==2.4.0.dev20240326 
+torch @ file:///tmp/torch-2.4.0a0%2Bgita166d4b-cp310-cp310-linux_x86_64.whl#sha256=074fca8e944362982db7dfe5d18de5720c18557e51657a347c908ccd9d37e354
 typing_extensions==4.11.0

--- a/pytorch/issue_122842/reproduce_bug.sh
+++ b/pytorch/issue_122842/reproduce_bug.sh
@@ -4,6 +4,8 @@ conda init
 conda create --name issue_122842 python==3.10 pip -y
 eval "$(conda shell.bash hook)"
 conda activate issue_122842
+pip install gdown==5.2.0
+gdown --fuzzy https://drive.google.com/file/d/1uVFLN5UxlfK4VTqCCsGzIFn4z1-Aqi6w/view?usp=sharing -O /tmp/
 pip install -r  requirements.txt
 if [[ $OSTYPE == 'darwin'* ]]
 then

--- a/pytorch/issue_122842/requirements.txt
+++ b/pytorch/issue_122842/requirements.txt
@@ -13,5 +13,5 @@ pytest==8.2.1
 sympy==1.12
 tabulate==0.9.0
 tomli==2.0.1
-torch @ https://download.pytorch.org/whl/nightly/cpu/torch-2.4.0.dev20240324%2Bcpu-cp310-cp310-linux_x86_64.whl#sha256=519e7e11a4de607dd9af4e2ff9024efcea47d75dec1d61d092a699c7f35d5ed7
+torch @ file:///tmp/torch-2.4.0a0%2Bgit848a2e8-cp310-cp310-linux_x86_64.whl#sha256=4a5803f52412f893fcb68110833bf09e056d4e3f8ebcb555a661c6007ea2e1d2
 typing_extensions==4.11.0


### PR DESCRIPTION
closes #184

Addresses PyTorch issues: 120188, 120647, 120762, 120803, 121174, 121188, 122126, 122692, 122771, 122842

Logs:
```
2025-01-07T13:45:23.1587623Z ##[group]Run run-tests -d
2025-01-07T13:45:23.1588826Z [36;1mrun-tests -d[0m
2025-01-07T13:45:23.1649330Z shell: /usr/bin/bash -e {0}
2025-01-07T13:45:23.1650262Z env:
2025-01-07T13:45:23.1651240Z   pythonLocation: /opt/hostedtoolcache/Python/3.11.11/x64
2025-01-07T13:45:23.1653108Z   LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.11.11/x64/lib
2025-01-07T13:45:23.1654352Z ##[endgroup]
2025-01-07T13:45:23.1867281Z ---------- Starting jax ----------
2025-01-07T13:45:23.1891904Z Start bug id issue_17020. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_17020.95W
2025-01-07T13:45:49.0996758Z End bug id issue_17020: Bug reproduction successful
2025-01-07T13:45:49.1046975Z Start bug id issue_17151. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_17151.2Sx
2025-01-07T13:46:33.9551799Z End bug id issue_17151: Bug reproduction successful
2025-01-07T13:46:33.9604258Z Start bug id issue_17294. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_17294.VJS
2025-01-07T13:46:48.0932625Z End bug id issue_17294: Bug reproduction successful
2025-01-07T13:46:48.0982363Z Start bug id issue_17448. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_17448.XQF
2025-01-07T13:47:00.7177640Z End bug id issue_17448: Bug reproduction successful
2025-01-07T13:47:00.7228472Z Start bug id issue_17690. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_17690.haU
2025-01-07T13:47:15.6674892Z End bug id issue_17690: Bug reproduction successful
2025-01-07T13:47:15.6725249Z Start bug id issue_17702. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_17702.S9I
2025-01-07T13:47:35.6363004Z End bug id issue_17702: Bug reproduction successful
2025-01-07T13:47:35.6420243Z Start bug id issue_17758. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_17758.AoT
2025-01-07T13:47:55.1424715Z End bug id issue_17758: Bug reproduction successful
2025-01-07T13:47:55.1479100Z Start bug id issue_17761. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_17761.b2E
2025-01-07T13:48:09.5965878Z End bug id issue_17761: Bug reproduction successful
2025-01-07T13:48:09.6035136Z Start bug id issue_17867. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_17867.yDl
2025-01-07T13:48:09.6057651Z End bug id issue_17867: Bug reproduction unsat prereqs
2025-01-07T13:48:09.6108886Z Start bug id issue_17922. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_17922.I0o
2025-01-07T13:48:24.5951857Z End bug id issue_17922: Bug reproduction successful
2025-01-07T13:48:24.6001966Z Start bug id issue_18004. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_18004.maV
2025-01-07T13:48:39.0753694Z End bug id issue_18004: Bug reproduction successful
2025-01-07T13:48:39.0803689Z Start bug id issue_18218. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_18218.VcU
2025-01-07T13:48:54.3488876Z End bug id issue_18218: Bug reproduction successful
2025-01-07T13:48:54.3539488Z Start bug id issue_18348. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_18348.u2d
2025-01-07T13:49:40.9160164Z End bug id issue_18348: Bug reproduction successful
2025-01-07T13:49:40.9212529Z Start bug id issue_18442. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_18442.HzE
2025-01-07T13:49:55.7950397Z End bug id issue_18442: Bug reproduction successful
2025-01-07T13:49:55.8001257Z Start bug id issue_18542. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_18542.LVl
2025-01-07T13:50:09.9751904Z End bug id issue_18542: Bug reproduction successful
2025-01-07T13:50:09.9804029Z Start bug id issue_18680. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_18680.aBM
2025-01-07T13:50:24.3389861Z End bug id issue_18680: Bug reproduction successful
2025-01-07T13:50:24.3439854Z Start bug id issue_18851. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_18851.Q6V
2025-01-07T13:50:47.3981659Z End bug id issue_18851: Bug reproduction successful
2025-01-07T13:50:47.4032464Z Start bug id issue_18937. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_18937.IW0
2025-01-07T13:51:01.2396022Z End bug id issue_18937: Bug reproduction successful
2025-01-07T13:51:01.2446872Z Start bug id issue_19011. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_19011.fEM
2025-01-07T13:51:20.2104255Z End bug id issue_19011: Bug reproduction successful
2025-01-07T13:51:20.2154767Z Start bug id issue_19059. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_19059.1It
2025-01-07T13:51:34.2979697Z End bug id issue_19059: Bug reproduction successful
2025-01-07T13:51:34.3030289Z Start bug id issue_19076. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_19076.6CA
2025-01-07T13:51:49.1897720Z End bug id issue_19076: Bug reproduction successful
2025-01-07T13:51:49.1947798Z Start bug id issue_19150. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_19150.43s
2025-01-07T13:52:07.6526378Z End bug id issue_19150: Bug reproduction successful
2025-01-07T13:52:07.6580588Z Start bug id issue_19334. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_19334.O8k
2025-01-07T13:52:21.6725491Z End bug id issue_19334: Bug reproduction successful
2025-01-07T13:52:21.6775353Z Start bug id issue_19356. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_19356.QKX
2025-01-07T13:52:39.7308739Z End bug id issue_19356: Bug reproduction successful
2025-01-07T13:52:39.7359327Z Start bug id issue_19362. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_19362.ose
2025-01-07T13:52:53.6548274Z End bug id issue_19362: Bug reproduction successful
2025-01-07T13:52:53.6599127Z Start bug id issue_19490. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_19490.j4P
2025-01-07T13:53:07.8236781Z End bug id issue_19490: Bug reproduction successful
2025-01-07T13:53:07.8287309Z Start bug id issue_19663. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_19663.4ax
2025-01-07T13:53:24.6042944Z End bug id issue_19663: Bug reproduction successful
2025-01-07T13:53:24.6093021Z Start bug id issue_19753. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_19753.K4S
2025-01-07T13:53:38.6110132Z End bug id issue_19753: Bug reproduction successful
2025-01-07T13:53:38.6160268Z Start bug id issue_19978. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_19978.WiE
2025-01-07T13:53:52.5382880Z End bug id issue_19978: Bug reproduction successful
2025-01-07T13:53:52.5432904Z Start bug id issue_20082. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_20082.Cgx
2025-01-07T13:54:07.1822032Z End bug id issue_20082: Bug reproduction successful
2025-01-07T13:54:07.1873374Z Start bug id issue_20267. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_20267.NME
2025-01-07T13:54:21.3484254Z End bug id issue_20267: Bug reproduction successful
2025-01-07T13:54:21.3535077Z Start bug id issue_20392. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_20392.n3b
2025-01-07T13:54:35.9949759Z End bug id issue_20392: Bug reproduction successful
2025-01-07T13:54:36.0003495Z Start bug id issue_20430. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_20430.rSO
2025-01-07T13:54:53.6030205Z End bug id issue_20430: Bug reproduction successful
2025-01-07T13:54:53.6080942Z Start bug id issue_20507. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_20507.dCp
2025-01-07T13:55:08.0365448Z End bug id issue_20507: Bug reproduction successful
2025-01-07T13:55:08.0415240Z Start bug id issue_20620. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_20620.zsq
2025-01-07T13:55:22.4927811Z End bug id issue_20620: Bug reproduction successful
2025-01-07T13:55:22.4978808Z Start bug id issue_20624. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_20624.9KA
2025-01-07T13:55:37.2416965Z End bug id issue_20624: Bug reproduction successful
2025-01-07T13:55:37.2470740Z Start bug id issue_20769. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_20769.yKl
2025-01-07T13:55:52.9119187Z End bug id issue_20769: Bug reproduction successful
2025-01-07T13:55:52.9169867Z Start bug id issue_20856. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_20856.Diz
2025-01-07T13:56:09.5981375Z End bug id issue_20856: Bug reproduction successful
2025-01-07T13:56:09.6031556Z Start bug id issue_20864. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_20864.FE3
2025-01-07T13:56:24.4245386Z End bug id issue_20864: Bug reproduction successful
2025-01-07T13:56:24.4295926Z Start bug id issue_21116. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_21116.log
2025-01-07T13:56:39.8056435Z End bug id issue_21116: Bug reproduction successful
2025-01-07T13:56:39.8106980Z Start bug id issue_21160. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_21160.ODj
2025-01-07T13:56:53.9784056Z End bug id issue_21160: Bug reproduction successful
2025-01-07T13:56:53.9834511Z Start bug id issue_22308. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/jax/issue_22308.0hn
2025-01-07T13:57:09.2645606Z End bug id issue_22308: Bug reproduction successful
2025-01-07T13:57:09.2659482Z ---------- Starting pytorch ----------
2025-01-07T13:57:09.2707508Z Start bug id issue_120188. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/pytorch/issue_120188.0Vf
2025-01-07T13:57:48.4994919Z End bug id issue_120188: Bug reproduction successful
2025-01-07T13:57:48.5049750Z Start bug id issue_120387. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/pytorch/issue_120387.hzY
2025-01-07T13:58:19.1197228Z End bug id issue_120387: Bug reproduction successful
2025-01-07T13:58:19.1247858Z Start bug id issue_120647. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/pytorch/issue_120647.DXg
2025-01-07T13:58:53.4221867Z End bug id issue_120647: Bug reproduction successful
2025-01-07T13:58:53.4272297Z Start bug id issue_120762. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/pytorch/issue_120762.hak
2025-01-07T13:59:28.6419426Z End bug id issue_120762: Bug reproduction successful
2025-01-07T13:59:28.6469496Z Start bug id issue_120803. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/pytorch/issue_120803.oSt
2025-01-07T14:00:02.2922606Z End bug id issue_120803: Bug reproduction successful
2025-01-07T14:00:02.2973248Z Start bug id issue_120875. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/pytorch/issue_120875.z6T
2025-01-07T14:00:02.3062552Z End bug id issue_120875: Bug reproduction unsat prereqs
2025-01-07T14:00:02.3112462Z Start bug id issue_120899. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/pytorch/issue_120899.CFV
2025-01-07T14:00:02.3146171Z End bug id issue_120899: Bug reproduction unsat prereqs
2025-01-07T14:00:02.3195248Z Start bug id issue_120903. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/pytorch/issue_120903.CmS
2025-01-07T14:00:28.8868233Z End bug id issue_120903: Bug reproduction successful
2025-01-07T14:00:28.8918702Z Start bug id issue_120998. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/pytorch/issue_120998.JWs
2025-01-07T14:00:28.9016552Z End bug id issue_120998: Bug reproduction unsat prereqs
2025-01-07T14:00:28.9066022Z Start bug id issue_121093. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/pytorch/issue_121093.SF3
2025-01-07T14:00:28.9197518Z End bug id issue_121093: Bug reproduction unsat prereqs
2025-01-07T14:00:28.9252552Z Start bug id issue_121138. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/pytorch/issue_121138.u7p
2025-01-07T14:00:50.2560084Z End bug id issue_121138: Bug reproduction successful
2025-01-07T14:00:50.2610651Z Start bug id issue_121174. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/pytorch/issue_121174.McG
2025-01-07T14:01:31.2006333Z End bug id issue_121174: Bug reproduction successful
2025-01-07T14:01:31.2057390Z Start bug id issue_121188. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/pytorch/issue_121188.iy5
2025-01-07T14:02:05.6201406Z End bug id issue_121188: Bug reproduction successful
2025-01-07T14:02:05.6251953Z Start bug id issue_121253. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/pytorch/issue_121253.SRz
2025-01-07T14:02:05.6348584Z End bug id issue_121253: Bug reproduction unsat prereqs
2025-01-07T14:02:05.6397706Z Start bug id issue_121320. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/pytorch/issue_121320.TS3
2025-01-07T14:02:05.6485775Z End bug id issue_121320: Bug reproduction unsat prereqs
2025-01-07T14:02:05.6535712Z Start bug id issue_121583. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/pytorch/issue_121583.845
2025-01-07T14:02:05.6568403Z End bug id issue_121583: Bug reproduction unsat prereqs
2025-01-07T14:02:05.6618440Z Start bug id issue_121671. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/pytorch/issue_121671.3yv
2025-01-07T14:02:05.6705197Z End bug id issue_121671: Bug reproduction unsat prereqs
2025-01-07T14:02:05.6753460Z Start bug id issue_122016. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/pytorch/issue_122016.pH8
2025-01-07T14:02:05.6790444Z End bug id issue_122016: Bug reproduction unsat prereqs
2025-01-07T14:02:05.6838821Z Start bug id issue_122085. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/pytorch/issue_122085.Gp0
2025-01-07T14:02:05.6927178Z End bug id issue_122085: Bug reproduction unsat prereqs
2025-01-07T14:02:05.6976171Z Start bug id issue_122126. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/pytorch/issue_122126.Mku
2025-01-07T14:02:41.0479893Z End bug id issue_122126: Bug reproduction successful
2025-01-07T14:02:41.0530454Z Start bug id issue_122296. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/pytorch/issue_122296.nyX
2025-01-07T14:02:41.0626876Z End bug id issue_122296: Bug reproduction unsat prereqs
2025-01-07T14:02:41.0676796Z Start bug id issue_122427. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/pytorch/issue_122427.7vS
2025-01-07T14:02:41.0710793Z End bug id issue_122427: Bug reproduction unsat prereqs
2025-01-07T14:02:41.0759426Z Start bug id issue_122692. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/pytorch/issue_122692.6Bp
2025-01-07T14:03:15.0082723Z End bug id issue_122692: Bug reproduction successful
2025-01-07T14:03:15.0133061Z Start bug id issue_122705. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/pytorch/issue_122705.T57
2025-01-07T14:03:15.0170742Z End bug id issue_122705: Bug reproduction unsat prereqs
2025-01-07T14:03:15.0222033Z Start bug id issue_122771. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/pytorch/issue_122771.KiP
2025-01-07T14:03:51.6530664Z End bug id issue_122771: Bug reproduction successful
2025-01-07T14:03:51.6581387Z Start bug id issue_122807. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/pytorch/issue_122807.Cas
2025-01-07T14:03:51.6672423Z End bug id issue_122807: Bug reproduction unsat prereqs
2025-01-07T14:03:51.6722438Z Start bug id issue_122842. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/pytorch/issue_122842.QZc
2025-01-07T14:04:26.4484090Z End bug id issue_122842: Bug reproduction successful
2025-01-07T14:04:26.4534806Z Start bug id issue_123288. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/pytorch/issue_123288.hsv
2025-01-07T14:05:05.7901660Z End bug id issue_123288: Bug reproduction successful
2025-01-07T14:05:05.7915030Z ---------- Starting tensorflow ----------
2025-01-07T14:05:05.7963637Z Start bug id issue_59084. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/tensorflow/issue_59084.fEh
2025-01-07T14:05:46.1393594Z End bug id issue_59084: Bug reproduction successful
2025-01-07T14:05:46.1444736Z Start bug id issue_59114. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/tensorflow/issue_59114.6PS
2025-01-07T14:06:20.1858406Z End bug id issue_59114: Bug reproduction successful
2025-01-07T14:06:20.1909185Z Start bug id issue_59123. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/tensorflow/issue_59123.4iP
2025-01-07T14:06:50.2097948Z End bug id issue_59123: Bug reproduction successful
2025-01-07T14:06:50.2148825Z Start bug id issue_60827. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/tensorflow/issue_60827.4vG
2025-01-07T14:07:20.9534845Z End bug id issue_60827: Bug reproduction successful
2025-01-07T14:07:20.9623644Z Start bug id issue_60932. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/tensorflow/issue_60932.WAj
2025-01-07T14:08:00.3792895Z End bug id issue_60932: Bug reproduction successful
2025-01-07T14:08:00.3846909Z Start bug id issue_61163. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/tensorflow/issue_61163.NOx
2025-01-07T14:08:35.1993234Z End bug id issue_61163: Bug reproduction successful
2025-01-07T14:08:35.2083505Z Start bug id issue_61761. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/tensorflow/issue_61761.oW4
2025-01-07T14:09:20.8288167Z End bug id issue_61761: Bug reproduction successful
2025-01-07T14:09:20.8340285Z Start bug id issue_61974. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/tensorflow/issue_61974.ucl
2025-01-07T14:09:50.4240902Z End bug id issue_61974: Bug reproduction successful
2025-01-07T14:09:50.4328212Z Start bug id issue_62072. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/tensorflow/issue_62072.NG4
2025-01-07T14:10:26.9791114Z End bug id issue_62072: Bug reproduction successful
2025-01-07T14:10:26.9869228Z Start bug id issue_62977. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/tensorflow/issue_62977.HI5
2025-01-07T14:11:04.4139811Z End bug id issue_62977: Bug reproduction successful
2025-01-07T14:11:04.4190903Z Start bug id issue_62981. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/tensorflow/issue_62981.6CC
2025-01-07T14:11:12.2836977Z Printing log for issue_62981:
2025-01-07T14:11:12.2849237Z no change     /usr/share/miniconda/condabin/conda
2025-01-07T14:11:12.2850328Z no change     /usr/share/miniconda/bin/conda
2025-01-07T14:11:12.2899828Z no change     /usr/share/miniconda/bin/conda-env
2025-01-07T14:11:12.2900602Z no change     /usr/share/miniconda/bin/activate
2025-01-07T14:11:12.2901394Z no change     /usr/share/miniconda/bin/deactivate
2025-01-07T14:11:12.2902231Z no change     /usr/share/miniconda/etc/profile.d/conda.sh
2025-01-07T14:11:12.2903054Z no change     /usr/share/miniconda/etc/fish/conf.d/conda.fish
2025-01-07T14:11:12.2903850Z no change     /usr/share/miniconda/shell/condabin/Conda.psm1
2025-01-07T14:11:12.2904767Z no change     /usr/share/miniconda/shell/condabin/conda-hook.ps1
2025-01-07T14:11:12.2905653Z no change     /usr/share/miniconda/lib/python3.12/site-packages/xontrib/conda.xsh
2025-01-07T14:11:12.2906534Z no change     /usr/share/miniconda/etc/profile.d/conda.csh
2025-01-07T14:11:12.2907290Z no change     /home/runner/.bashrc
2025-01-07T14:11:12.2907774Z No action taken.
2025-01-07T14:11:12.2908217Z Channels:
2025-01-07T14:11:12.2908786Z  - defaults
2025-01-07T14:11:12.2909188Z Platform: linux-64
2025-01-07T14:11:12.2909840Z Collecting package metadata (repodata.json): ...working... done
2025-01-07T14:11:12.2910717Z Solving environment: ...working... done
2025-01-07T14:11:12.2911072Z 
2025-01-07T14:11:12.2911257Z ## Package Plan ##
2025-01-07T14:11:12.2911550Z 
2025-01-07T14:11:12.2911900Z   environment location: /usr/share/miniconda/envs/issue_62981
2025-01-07T14:11:12.2912338Z 
2025-01-07T14:11:12.2912702Z   added / updated specs:
2025-01-07T14:11:12.2913154Z     - pip
2025-01-07T14:11:12.2913619Z     - python==3.11
2025-01-07T14:11:12.2913846Z 
2025-01-07T14:11:12.2913853Z 
2025-01-07T14:11:12.2914285Z The following NEW packages will be INSTALLED:
2025-01-07T14:11:12.2914674Z 
2025-01-07T14:11:12.2915159Z   _libgcc_mutex      pkgs/main/linux-64::_libgcc_mutex-0.1-main 
2025-01-07T14:11:12.2915941Z   _openmp_mutex      pkgs/main/linux-64::_openmp_mutex-5.1-1_gnu 
2025-01-07T14:11:12.2916872Z   bzip2              pkgs/main/linux-64::bzip2-1.0.8-h5eee18b_6 
2025-01-07T14:11:12.2917734Z   ca-certificates    pkgs/main/linux-64::ca-certificates-2024.11.26-h06a4308_0 
2025-01-07T14:11:12.2918650Z   ld_impl_linux-64   pkgs/main/linux-64::ld_impl_linux-64-2.40-h12ee557_0 
2025-01-07T14:11:12.2919605Z   libffi             pkgs/main/linux-64::libffi-3.4.4-h6a678d5_1 
2025-01-07T14:11:12.2920409Z   libgcc-ng          pkgs/main/linux-64::libgcc-ng-11.2.0-h1234567_1 
2025-01-07T14:11:12.2921174Z   libgomp            pkgs/main/linux-64::libgomp-11.2.0-h1234567_1 
2025-01-07T14:11:12.2922068Z   libstdcxx-ng       pkgs/main/linux-64::libstdcxx-ng-11.2.0-h1234567_1 
2025-01-07T14:11:12.2923031Z   libuuid            pkgs/main/linux-64::libuuid-1.41.5-h5eee18b_0 
2025-01-07T14:11:12.2923772Z   ncurses            pkgs/main/linux-64::ncurses-6.4-h6a678d5_0 
2025-01-07T14:11:12.2925212Z   openssl            pkgs/main/linux-64::openssl-1.1.1w-h7f8727e_0 
2025-01-07T14:11:12.2926006Z   pip                pkgs/main/linux-64::pip-24.2-py311h06a4308_0 
2025-01-07T14:11:12.2926717Z   python             pkgs/main/linux-64::python-3.11.0-h7a1cb2a_3 
2025-01-07T14:11:12.2927671Z   readline           pkgs/main/linux-64::readline-8.2-h5eee18b_0 
2025-01-07T14:11:12.2928497Z   setuptools         pkgs/main/linux-64::setuptools-75.1.0-py311h06a4308_0 
2025-01-07T14:11:12.2929599Z   sqlite             pkgs/main/linux-64::sqlite-3.45.3-h5eee18b_0 
2025-01-07T14:11:12.2930504Z   tk                 pkgs/main/linux-64::tk-8.6.14-h39e8969_0 
2025-01-07T14:11:12.2931167Z   tzdata             pkgs/main/noarch::tzdata-2024b-h04d1e81_0 
2025-01-07T14:11:12.2932397Z   wheel              pkgs/main/linux-64::wheel-0.44.0-py311h06a4308_0 
2025-01-07T14:11:12.2933290Z   xz                 pkgs/main/linux-64::xz-5.4.6-h5eee18b_1 
2025-01-07T14:11:12.2933966Z   zlib               pkgs/main/linux-64::zlib-1.2.13-h5eee18b_1 
2025-01-07T14:11:12.2934389Z 
2025-01-07T14:11:12.2934396Z 
2025-01-07T14:11:12.2934402Z 
2025-01-07T14:11:12.2934704Z Downloading and Extracting Packages: ...working... done
2025-01-07T14:11:12.2935606Z Preparing transaction: ...working... done
2025-01-07T14:11:12.2936230Z Verifying transaction: ...working... done
2025-01-07T14:11:12.2936786Z Executing transaction: ...working... done
2025-01-07T14:11:12.2937487Z #
2025-01-07T14:11:12.2937909Z # To activate this environment, use
2025-01-07T14:11:12.2938384Z #
2025-01-07T14:11:12.2938929Z #     $ conda activate issue_62981
2025-01-07T14:11:12.2939437Z #
2025-01-07T14:11:12.2941683Z # To deactivate an active environment, use
2025-01-07T14:11:12.2942460Z #
2025-01-07T14:11:12.2942875Z #     $ conda deactivate
2025-01-07T14:11:12.2943146Z 
2025-01-07T14:11:12.2943445Z Collecting absl-py==2.1.0 (from -r requirements.txt (line 1))
2025-01-07T14:11:12.2944462Z   Using cached absl_py-2.1.0-py3-none-any.whl.metadata (2.3 kB)
2025-01-07T14:11:12.2945312Z Collecting astunparse==1.6.3 (from -r requirements.txt (line 2))
2025-01-07T14:11:12.2946298Z   Using cached astunparse-1.6.3-py2.py3-none-any.whl.metadata (4.4 kB)
2025-01-07T14:11:12.2947153Z Collecting cachetools==5.4.0 (from -r requirements.txt (line 3))
2025-01-07T14:11:12.2948052Z   Downloading cachetools-5.4.0-py3-none-any.whl.metadata (5.3 kB)
2025-01-07T14:11:12.2949041Z Collecting certifi==2024.7.4 (from -r requirements.txt (line 4))
2025-01-07T14:11:12.2949882Z   Downloading certifi-2024.7.4-py3-none-any.whl.metadata (2.2 kB)
2025-01-07T14:11:12.2950779Z Collecting charset-normalizer==3.3.2 (from -r requirements.txt (line 5))
2025-01-07T14:11:12.2952081Z   Using cached charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (33 kB)
2025-01-07T14:11:12.2953211Z Collecting flatbuffers==24.3.25 (from -r requirements.txt (line 6))
2025-01-07T14:11:12.2954300Z   Using cached flatbuffers-24.3.25-py2.py3-none-any.whl.metadata (850 bytes)
2025-01-07T14:11:12.2955292Z Collecting gast==0.6.0 (from -r requirements.txt (line 7))
2025-01-07T14:11:12.2956069Z   Downloading gast-0.6.0-py3-none-any.whl.metadata (1.3 kB)
2025-01-07T14:11:12.2956934Z Collecting google-auth==2.32.0 (from -r requirements.txt (line 8))
2025-01-07T14:11:12.2957917Z   Downloading google_auth-2.32.0-py2.py3-none-any.whl.metadata (4.7 kB)
2025-01-07T14:11:12.2958933Z Collecting google-auth-oauthlib==1.0.0 (from -r requirements.txt (line 9))
2025-01-07T14:11:12.2959927Z   Using cached google_auth_oauthlib-1.0.0-py2.py3-none-any.whl.metadata (2.7 kB)
2025-01-07T14:11:12.2960961Z Collecting google-pasta==0.2.0 (from -r requirements.txt (line 10))
2025-01-07T14:11:12.2961865Z   Using cached google_pasta-0.2.0-py3-none-any.whl.metadata (814 bytes)
2025-01-07T14:11:12.2962701Z Collecting grpcio==1.65.1 (from -r requirements.txt (line 11))
2025-01-07T14:11:12.2963832Z   Downloading grpcio-1.65.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (3.3 kB)
2025-01-07T14:11:12.2965170Z Collecting h5py==3.11.0 (from -r requirements.txt (line 12))
2025-01-07T14:11:12.2966107Z   Using cached h5py-3.11.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (2.5 kB)
2025-01-07T14:11:12.2967158Z Collecting idna==3.7 (from -r requirements.txt (line 13))
2025-01-07T14:11:12.2967955Z   Using cached idna-3.7-py3-none-any.whl.metadata (9.9 kB)
2025-01-07T14:11:12.2968735Z Collecting iniconfig==2.0.0 (from -r requirements.txt (line 14))
2025-01-07T14:11:12.2969841Z   Using cached iniconfig-2.0.0-py3-none-any.whl.metadata (2.6 kB)
2025-01-07T14:11:12.2970752Z Collecting keras==2.14.0 (from -r requirements.txt (line 15))
2025-01-07T14:11:12.3001208Z   Using cached keras-2.14.0-py3-none-any.whl.metadata (2.4 kB)
2025-01-07T14:11:12.3002183Z Collecting libclang==18.1.1 (from -r requirements.txt (line 16))
2025-01-07T14:11:12.3003299Z   Using cached libclang-18.1.1-py2.py3-none-manylinux2010_x86_64.whl.metadata (5.2 kB)
2025-01-07T14:11:12.3004278Z Collecting Markdown==3.6 (from -r requirements.txt (line 17))
2025-01-07T14:11:12.3005206Z   Using cached Markdown-3.6-py3-none-any.whl.metadata (7.0 kB)
2025-01-07T14:11:12.3006222Z Collecting markdown-it-py==3.0.0 (from -r requirements.txt (line 18))
2025-01-07T14:11:12.3007144Z   Using cached markdown_it_py-3.0.0-py3-none-any.whl.metadata (6.9 kB)
2025-01-07T14:11:12.3008183Z Collecting MarkupSafe==2.1.5 (from -r requirements.txt (line 19))
2025-01-07T14:11:12.3009284Z   Using cached MarkupSafe-2.1.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (3.0 kB)
2025-01-07T14:11:12.3010361Z Collecting mdurl==0.1.2 (from -r requirements.txt (line 20))
2025-01-07T14:11:12.3011313Z   Using cached mdurl-0.1.2-py3-none-any.whl.metadata (1.6 kB)
2025-01-07T14:11:12.3012326Z Collecting ml-dtypes==0.2.0 (from -r requirements.txt (line 21))
2025-01-07T14:11:12.3013411Z   Using cached ml_dtypes-0.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (20 kB)
2025-01-07T14:11:12.3014626Z Collecting namex==0.0.8 (from -r requirements.txt (line 22))
2025-01-07T14:11:12.3015437Z   Downloading namex-0.0.8-py3-none-any.whl.metadata (246 bytes)
2025-01-07T14:11:12.3016347Z Collecting numpy==1.26.4 (from -r requirements.txt (line 23))
2025-01-07T14:11:12.3017526Z   Using cached numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (61 kB)
2025-01-07T14:11:12.3018635Z Collecting oauthlib==3.2.2 (from -r requirements.txt (line 24))
2025-01-07T14:11:12.3019482Z   Using cached oauthlib-3.2.2-py3-none-any.whl.metadata (7.5 kB)
2025-01-07T14:11:12.3020453Z Collecting opt-einsum==3.3.0 (from -r requirements.txt (line 25))
2025-01-07T14:11:12.3021304Z   Using cached opt_einsum-3.3.0-py3-none-any.whl.metadata (6.5 kB)
2025-01-07T14:11:12.3022124Z Collecting optree==0.12.1 (from -r requirements.txt (line 26))
2025-01-07T14:11:12.3023351Z   Downloading optree-0.12.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (47 kB)
2025-01-07T14:11:12.3024458Z Collecting packaging==24.1 (from -r requirements.txt (line 27))
2025-01-07T14:11:12.3025339Z   Using cached packaging-24.1-py3-none-any.whl.metadata (3.2 kB)
2025-01-07T14:11:12.3026770Z Collecting pluggy==1.5.0 (from -r requirements.txt (line 28))
2025-01-07T14:11:12.3027626Z   Using cached pluggy-1.5.0-py3-none-any.whl.metadata (4.8 kB)
2025-01-07T14:11:12.3028527Z Collecting protobuf==4.25.4 (from -r requirements.txt (line 29))
2025-01-07T14:11:12.3029601Z   Downloading protobuf-4.25.4-cp37-abi3-manylinux2014_x86_64.whl.metadata (541 bytes)
2025-01-07T14:11:12.3030603Z Collecting pyasn1==0.6.0 (from -r requirements.txt (line 30))
2025-01-07T14:11:12.3031499Z   Using cached pyasn1-0.6.0-py2.py3-none-any.whl.metadata (8.3 kB)
2025-01-07T14:11:12.3032511Z Collecting pyasn1_modules==0.4.0 (from -r requirements.txt (line 31))
2025-01-07T14:11:12.3033483Z   Using cached pyasn1_modules-0.4.0-py3-none-any.whl.metadata (3.4 kB)
2025-01-07T14:11:12.3034421Z Collecting Pygments==2.18.0 (from -r requirements.txt (line 32))
2025-01-07T14:11:12.3035736Z   Using cached pygments-2.18.0-py3-none-any.whl.metadata (2.5 kB)
2025-01-07T14:11:12.3036687Z Collecting pytest==8.3.2 (from -r requirements.txt (line 33))
2025-01-07T14:11:12.3037517Z   Using cached pytest-8.3.2-py3-none-any.whl.metadata (7.5 kB)
2025-01-07T14:11:12.3038512Z Collecting requests==2.32.3 (from -r requirements.txt (line 34))
2025-01-07T14:11:12.3039440Z   Using cached requests-2.32.3-py3-none-any.whl.metadata (4.6 kB)
2025-01-07T14:11:12.3040356Z Collecting requests-oauthlib==2.0.0 (from -r requirements.txt (line 35))
2025-01-07T14:11:12.3041840Z   Using cached requests_oauthlib-2.0.0-py2.py3-none-any.whl.metadata (11 kB)
2025-01-07T14:11:12.3042790Z Collecting rich==13.7.1 (from -r requirements.txt (line 36))
2025-01-07T14:11:12.3043622Z   Using cached rich-13.7.1-py3-none-any.whl.metadata (18 kB)
2025-01-07T14:11:12.3044648Z Collecting rsa==4.9 (from -r requirements.txt (line 37))
2025-01-07T14:11:12.3045398Z   Using cached rsa-4.9-py3-none-any.whl.metadata (4.2 kB)
2025-01-07T14:11:12.3046191Z Collecting six==1.16.0 (from -r requirements.txt (line 38))
2025-01-07T14:11:12.3047216Z   Using cached six-1.16.0-py2.py3-none-any.whl.metadata (1.8 kB)
2025-01-07T14:11:12.3048067Z Collecting tensorboard==2.14.1 (from -r requirements.txt (line 39))
2025-01-07T14:11:12.3048969Z   Using cached tensorboard-2.14.1-py3-none-any.whl.metadata (1.7 kB)
2025-01-07T14:11:12.3050135Z Collecting tensorboard-data-server==0.7.2 (from -r requirements.txt (line 40))
2025-01-07T14:11:12.3051222Z   Using cached tensorboard_data_server-0.7.2-py3-none-manylinux_2_31_x86_64.whl.metadata (1.1 kB)
2025-01-07T14:11:12.3052833Z Collecting tensorflow==2.14.1 (from -r requirements.txt (line 41))
2025-01-07T14:11:12.3054151Z   Downloading tensorflow-2.14.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (4.1 kB)
2025-01-07T14:11:12.3055340Z Collecting tensorflow-estimator==2.14.0 (from -r requirements.txt (line 42))
2025-01-07T14:11:12.3056344Z   Using cached tensorflow_estimator-2.14.0-py2.py3-none-any.whl.metadata (1.3 kB)
2025-01-07T14:11:12.3057656Z Collecting tensorflow-io-gcs-filesystem==0.37.1 (from -r requirements.txt (line 43))
2025-01-07T14:11:12.3059032Z   Using cached tensorflow_io_gcs_filesystem-0.37.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (14 kB)
2025-01-07T14:11:12.3061432Z ERROR: Ignored the following versions that require a different python version: 0.28.0 Requires-Python >=3.7, <3.11; 1.21.2 Requires-Python >=3.7,<3.11; 1.21.3 Requires-Python >=3.7,<3.11; 1.21.4 Requires-Python >=3.7,<3.11; 1.21.5 Requires-Python >=3.7,<3.11; 1.21.6 Requires-Python >=3.7,<3.11
2025-01-07T14:11:12.3063565Z ERROR: Could not find a version that satisfies the requirement tensorflow-macos==2.14.1 (from versions: none)
2025-01-07T14:11:12.3064705Z ERROR: No matching distribution found for tensorflow-macos==2.14.1
2025-01-07T14:11:12.3065673Z ./reproduce_bug.sh: line 8: pytest: command not found
2025-01-07T14:11:12.3066173Z 
2025-01-07T14:11:12.3066610Z Remove all packages in environment /usr/share/miniconda/envs/issue_62981:
2025-01-07T14:11:12.3067160Z 
2025-01-07T14:11:12.3067167Z 
2025-01-07T14:11:12.3067409Z ## Package Plan ##
2025-01-07T14:11:12.3067715Z 
2025-01-07T14:11:12.3068159Z   environment location: /usr/share/miniconda/envs/issue_62981
2025-01-07T14:11:12.3068709Z 
2025-01-07T14:11:12.3068717Z 
2025-01-07T14:11:12.3068947Z The following packages will be REMOVED:
2025-01-07T14:11:12.3069360Z 
2025-01-07T14:11:12.3069618Z   _libgcc_mutex-0.1-main
2025-01-07T14:11:12.3070216Z   _openmp_mutex-5.1-1_gnu
2025-01-07T14:11:12.3070780Z   bzip2-1.0.8-h5eee18b_6
2025-01-07T14:11:12.3071351Z   ca-certificates-2024.11.26-h06a4308_0
2025-01-07T14:11:12.3072037Z   ld_impl_linux-64-2.40-h12ee557_0
2025-01-07T14:11:12.3072707Z   libffi-3.4.4-h6a678d5_1
2025-01-07T14:11:12.3073271Z   libgcc-ng-11.2.0-h1234567_1
2025-01-07T14:11:12.3073900Z   libgomp-11.2.0-h1234567_1
2025-01-07T14:11:12.3074484Z   libstdcxx-ng-11.2.0-h1234567_1
2025-01-07T14:11:12.3075086Z   libuuid-1.41.5-h5eee18b_0
2025-01-07T14:11:12.3075973Z   ncurses-6.4-h6a678d5_0
2025-01-07T14:11:12.3076577Z   openssl-1.1.1w-h7f8727e_0
2025-01-07T14:11:12.3077147Z   pip-24.2-py311h06a4308_0
2025-01-07T14:11:12.3077704Z   python-3.11.0-h7a1cb2a_3
2025-01-07T14:11:12.3078237Z   readline-8.2-h5eee18b_0
2025-01-07T14:11:12.3078783Z   setuptools-75.1.0-py311h06a4308_0
2025-01-07T14:11:12.3079413Z   sqlite-3.45.3-h5eee18b_0
2025-01-07T14:11:12.3080010Z   tk-8.6.14-h39e8969_0
2025-01-07T14:11:12.3080532Z   tzdata-2024b-h04d1e81_0
2025-01-07T14:11:12.3081164Z   wheel-0.44.0-py311h06a4308_0
2025-01-07T14:11:12.3084254Z   xz-5.4.6-h5eee18b_1
2025-01-07T14:11:12.3084905Z   zlib-1.2.13-h5eee18b_1
2025-01-07T14:11:12.3085182Z 
2025-01-07T14:11:12.3085190Z 
2025-01-07T14:11:12.3085570Z Preparing transaction: ...working... done
2025-01-07T14:11:12.3086290Z Verifying transaction: ...working... done
2025-01-07T14:11:12.3086986Z Executing transaction: ...working... done
2025-01-07T14:11:12.3087697Z End bug id issue_62981: Bug reproduction failed
2025-01-07T14:11:12.3089084Z Start bug id issue_63575. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/tensorflow/issue_63575.YzM
2025-01-07T14:11:50.0421596Z End bug id issue_63575: Bug reproduction successful
2025-01-07T14:11:50.0472440Z Start bug id issue_64023. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/tensorflow/issue_64023.Iri
2025-01-07T14:12:25.4074429Z End bug id issue_64023: Bug reproduction successful
2025-01-07T14:12:25.4125528Z Start bug id issue_64256. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/tensorflow/issue_64256.diV
2025-01-07T14:12:54.9842017Z End bug id issue_64256: Bug reproduction successful
2025-01-07T14:12:54.9899869Z Start bug id issue_64392. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/tensorflow/issue_64392.T7F
2025-01-07T14:13:36.0876821Z End bug id issue_64392: Bug reproduction successful
2025-01-07T14:13:36.0927741Z Start bug id issue_64393. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/tensorflow/issue_64393.r7o
2025-01-07T14:14:17.8969950Z End bug id issue_64393: Bug reproduction successful
2025-01-07T14:14:17.9020701Z Start bug id issue_64443. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/tensorflow/issue_64443.nUw
2025-01-07T14:14:49.2271767Z End bug id issue_64443: Bug reproduction successful
2025-01-07T14:14:49.2321775Z Start bug id issue_64548. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/tensorflow/issue_64548.jR1
2025-01-07T14:15:21.4304651Z End bug id issue_64548: Bug reproduction successful
2025-01-07T14:15:21.4355324Z Start bug id issue_64576. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/tensorflow/issue_64576.9Pz
2025-01-07T14:15:52.0109374Z End bug id issue_64576: Bug reproduction successful
2025-01-07T14:15:52.0159160Z Start bug id issue_65629. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/tensorflow/issue_65629.HDT
2025-01-07T14:16:23.6425143Z End bug id issue_65629: Bug reproduction successful
2025-01-07T14:16:23.6476369Z Start bug id issue_65865. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/tensorflow/issue_65865.TE1
2025-01-07T14:16:57.5372616Z End bug id issue_65865: Bug reproduction successful
2025-01-07T14:16:57.5422591Z Start bug id issue_65869. Log: /tmp/dnnbugs.01-07-2025-13:45:23.vuV/tensorflow/issue_65869.TbN
2025-01-07T14:17:35.6699413Z End bug id issue_65869: Bug reproduction successful
2025-01-07T14:17:35.6705578Z 
2025-01-07T14:17:35.6706249Z ---- Summary ----
2025-01-07T14:17:35.6707200Z Library    | Total | Pass  | Fail  | Vio-Pre   
2025-01-07T14:17:35.6964394Z jax        | 42    | 41    | 0     | 1    
2025-01-07T14:17:35.7163472Z pytorch    | 28    | 14    | 0     | 14   
2025-01-07T14:17:35.7395494Z tensorflow | 22    | 21    | 1     | 0    
```