### PR TITLE
Use compiled source binary to reproduce issue 22305 with De-Indexed JAX nightly build

### DIFF
--- a/jax/issue_22305/reproduce_bug.sh
+++ b/jax/issue_22305/reproduce_bug.sh
@@ -4,6 +4,8 @@ conda init
 conda create --name issue_22305 python==3.11 pip -y
 eval "$(conda shell.bash hook)"
 conda activate issue_22305
+pip install gdown==5.2.0
+gdown --fuzzy https://drive.google.com/file/d/1KkQqFT8J2d82wabZT8efqFNX4Jud-RuA/view?usp=sharing -O /tmp/
 pip install -r requirements.txt
 pytest -sx
 returncode=$?

--- a/jax/issue_22305/requirements.txt
+++ b/jax/issue_22305/requirements.txt
@@ -1,6 +1,6 @@
 iniconfig==2.0.0
-jax @ https://storage.googleapis.com/jax-releases/nightly/jax/jax-0.4.31.dev20240707-py3-none-any.whl#sha256=ec1670cc829507dc1226ca7ec7b8ef1b4c90a6c0f3e9d480e302116bc0bd3fff
-jaxlib @ https://storage.googleapis.com/jax-releases/nightly/nocuda/jaxlib-0.4.31.dev20240707-cp311-cp311-manylinux2014_x86_64.whl#sha256=4f5b17bef4044ee792eb579d1fbe292d842a90f4816d53c189f3f7ce4cb15bc1
+jax @ file:///tmp/jax-0.4.31.dev20240707%2Bceea8dc3f-py3-none-any.whl#sha256=9806334273522f246dfdb20b39194f16a08580c7f74a29b36f588d3dd67a41ca
+jaxlib==0.4.31
 ml-dtypes==0.4.0
 numpy==2.0.0
 opt-einsum==3.3.0


### PR DESCRIPTION
closes #189 

Logs:
```
no change     /home/amanks/miniconda3/condabin/conda
no change     /home/amanks/miniconda3/bin/conda
no change     /home/amanks/miniconda3/bin/conda-env
no change     /home/amanks/miniconda3/bin/activate
no change     /home/amanks/miniconda3/bin/deactivate
no change     /home/amanks/miniconda3/etc/profile.d/conda.sh
no change     /home/amanks/miniconda3/etc/fish/conf.d/conda.fish
no change     /home/amanks/miniconda3/shell/condabin/Conda.psm1
no change     /home/amanks/miniconda3/shell/condabin/conda-hook.ps1
no change     /home/amanks/miniconda3/lib/python3.12/site-packages/xontrib/conda.xsh
no change     /home/amanks/miniconda3/etc/profile.d/conda.csh
no change     /home/amanks/.bashrc
No action taken.
Channels:
 - defaults
Platform: linux-64
Collecting package metadata (repodata.json): done
Solving environment: done

## Package Plan ##

  environment location: /home/amanks/miniconda3/envs/issue_22305

  added / updated specs:
    - pip
    - python==3.11


The following NEW packages will be INSTALLED:

  _libgcc_mutex      pkgs/main/linux-64::_libgcc_mutex-0.1-main 
  _openmp_mutex      pkgs/main/linux-64::_openmp_mutex-5.1-1_gnu 
  bzip2              pkgs/main/linux-64::bzip2-1.0.8-h5eee18b_6 
  ca-certificates    pkgs/main/linux-64::ca-certificates-2024.12.31-h06a4308_0 
  ld_impl_linux-64   pkgs/main/linux-64::ld_impl_linux-64-2.40-h12ee557_0 
  libffi             pkgs/main/linux-64::libffi-3.4.4-h6a678d5_1 
  libgcc-ng          pkgs/main/linux-64::libgcc-ng-11.2.0-h1234567_1 
  libgomp            pkgs/main/linux-64::libgomp-11.2.0-h1234567_1 
  libstdcxx-ng       pkgs/main/linux-64::libstdcxx-ng-11.2.0-h1234567_1 
  libuuid            pkgs/main/linux-64::libuuid-1.41.5-h5eee18b_0 
  ncurses            pkgs/main/linux-64::ncurses-6.4-h6a678d5_0 
  openssl            pkgs/main/linux-64::openssl-1.1.1w-h7f8727e_0 
  pip                pkgs/main/linux-64::pip-24.2-py311h06a4308_0 
  python             pkgs/main/linux-64::python-3.11.0-h7a1cb2a_3 
  readline           pkgs/main/linux-64::readline-8.2-h5eee18b_0 
  setuptools         pkgs/main/linux-64::setuptools-75.1.0-py311h06a4308_0 
  sqlite             pkgs/main/linux-64::sqlite-3.45.3-h5eee18b_0 
  tk                 pkgs/main/linux-64::tk-8.6.14-h39e8969_0 
  tzdata             pkgs/main/noarch::tzdata-2024b-h04d1e81_0 
  wheel              pkgs/main/linux-64::wheel-0.44.0-py311h06a4308_0 
  xz                 pkgs/main/linux-64::xz-5.4.6-h5eee18b_1 
  zlib               pkgs/main/linux-64::zlib-1.2.13-h5eee18b_1 



Downloading and Extracting Packages:

Preparing transaction: done
Verifying transaction: done
Executing transaction: done
#
# To activate this environment, use
#
#     $ conda activate issue_22305
#
# To deactivate an active environment, use
#
#     $ conda deactivate

Collecting gdown==5.2.0
  Using cached gdown-5.2.0-py3-none-any.whl.metadata (5.8 kB)
Collecting beautifulsoup4 (from gdown==5.2.0)
  Using cached beautifulsoup4-4.12.3-py3-none-any.whl.metadata (3.8 kB)
Collecting filelock (from gdown==5.2.0)
  Using cached filelock-3.16.1-py3-none-any.whl.metadata (2.9 kB)
Collecting requests[socks] (from gdown==5.2.0)
  Using cached requests-2.32.3-py3-none-any.whl.metadata (4.6 kB)
Collecting tqdm (from gdown==5.2.0)
  Using cached tqdm-4.67.1-py3-none-any.whl.metadata (57 kB)
Collecting soupsieve>1.2 (from beautifulsoup4->gdown==5.2.0)
  Using cached soupsieve-2.6-py3-none-any.whl.metadata (4.6 kB)
Collecting charset-normalizer<4,>=2 (from requests[socks]->gdown==5.2.0)
  Using cached charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (35 kB)
Collecting idna<4,>=2.5 (from requests[socks]->gdown==5.2.0)
  Using cached idna-3.10-py3-none-any.whl.metadata (10 kB)
Collecting urllib3<3,>=1.21.1 (from requests[socks]->gdown==5.2.0)
  Using cached urllib3-2.3.0-py3-none-any.whl.metadata (6.5 kB)
Collecting certifi>=2017.4.17 (from requests[socks]->gdown==5.2.0)
  Using cached certifi-2024.12.14-py3-none-any.whl.metadata (2.3 kB)
Collecting PySocks!=1.5.7,>=1.5.6 (from requests[socks]->gdown==5.2.0)
  Using cached PySocks-1.7.1-py3-none-any.whl.metadata (13 kB)
Using cached gdown-5.2.0-py3-none-any.whl (18 kB)
Using cached beautifulsoup4-4.12.3-py3-none-any.whl (147 kB)
Using cached filelock-3.16.1-py3-none-any.whl (16 kB)
Using cached tqdm-4.67.1-py3-none-any.whl (78 kB)
Using cached certifi-2024.12.14-py3-none-any.whl (164 kB)
Using cached charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (143 kB)
Using cached idna-3.10-py3-none-any.whl (70 kB)
Using cached PySocks-1.7.1-py3-none-any.whl (16 kB)
Using cached soupsieve-2.6-py3-none-any.whl (36 kB)
Using cached urllib3-2.3.0-py3-none-any.whl (128 kB)
Using cached requests-2.32.3-py3-none-any.whl (64 kB)
Installing collected packages: urllib3, tqdm, soupsieve, PySocks, idna, filelock, charset-normalizer, certifi, requests, beautifulsoup4, gdown
Successfully installed PySocks-1.7.1 beautifulsoup4-4.12.3 certifi-2024.12.14 charset-normalizer-3.4.1 filelock-3.16.1 gdown-5.2.0 idna-3.10 requests-2.32.3 soupsieve-2.6 tqdm-4.67.1 urllib3-2.3.0
Downloading...
From: https://drive.google.com/uc?id=1KkQqFT8J2d82wabZT8efqFNX4Jud-RuA
To: /tmp/jax-0.4.31.dev20240707+ceea8dc3f-py3-none-any.whl
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2.03M/2.03M [00:01<00:00, 1.62MB/s]
Processing /tmp/jax-0.4.31.dev20240707+ceea8dc3f-py3-none-any.whl (from -r requirements.txt (line 2))
Collecting iniconfig==2.0.0 (from -r requirements.txt (line 1))
  Using cached iniconfig-2.0.0-py3-none-any.whl.metadata (2.6 kB)
Collecting jaxlib==0.4.31 (from -r requirements.txt (line 3))
  Using cached jaxlib-0.4.31-cp311-cp311-manylinux2014_x86_64.whl.metadata (983 bytes)
Collecting ml-dtypes==0.4.0 (from -r requirements.txt (line 4))
  Using cached ml_dtypes-0.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (20 kB)
Collecting numpy==2.0.0 (from -r requirements.txt (line 5))
  Using cached numpy-2.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (60 kB)
Collecting opt-einsum==3.3.0 (from -r requirements.txt (line 6))
  Using cached opt_einsum-3.3.0-py3-none-any.whl.metadata (6.5 kB)
Collecting packaging==24.1 (from -r requirements.txt (line 7))
  Using cached packaging-24.1-py3-none-any.whl.metadata (3.2 kB)
Collecting pluggy==1.5.0 (from -r requirements.txt (line 8))
  Using cached pluggy-1.5.0-py3-none-any.whl.metadata (4.8 kB)
Collecting pytest==8.2.2 (from -r requirements.txt (line 9))
  Using cached pytest-8.2.2-py3-none-any.whl.metadata (7.6 kB)
Collecting scipy==1.14.0 (from -r requirements.txt (line 10))
  Using cached scipy-1.14.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (60 kB)
Using cached iniconfig-2.0.0-py3-none-any.whl (5.9 kB)
Using cached jaxlib-0.4.31-cp311-cp311-manylinux2014_x86_64.whl (88.1 MB)
Using cached ml_dtypes-0.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (2.2 MB)
Using cached numpy-2.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (19.3 MB)
Using cached opt_einsum-3.3.0-py3-none-any.whl (65 kB)
Using cached packaging-24.1-py3-none-any.whl (53 kB)
Using cached pluggy-1.5.0-py3-none-any.whl (20 kB)
Using cached pytest-8.2.2-py3-none-any.whl (339 kB)
Using cached scipy-1.14.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (41.1 MB)
Installing collected packages: pluggy, packaging, numpy, iniconfig, scipy, pytest, opt-einsum, ml-dtypes, jaxlib, jax
Successfully installed iniconfig-2.0.0 jax-0.4.31.dev20240707+ceea8dc3f jaxlib-0.4.31 ml-dtypes-0.4.0 numpy-2.0.0 opt-einsum-3.3.0 packaging-24.1 pluggy-1.5.0 pytest-8.2.2 scipy-1.14.0
=================================================================================== test session starts ====================================================================================
platform linux -- Python 3.11.0, pytest-8.2.2, pluggy-1.5.0
rootdir: /home/amanks/dnnbugs/jax/issue_22305
collected 1 item                                                                                                                                                                           

test_issue_22305.py Jax issue no. 22305
jax:    0.4.31.dev20240707+ceea8dc3f
jaxlib: 0.4.31
numpy:  2.0.0
python: 3.11.0 (main, Mar  1 2023, 18:26:19) [GCC 11.2.0]
jax.devices (1 total, 1 local): [CpuDevice(id=0)]
process_count: 1
platform: uname_result(system='Linux', node='fedoravm', release='6.12.7-100.fc40.x86_64', version='#1 SMP PREEMPT_DYNAMIC Fri Dec 27 17:00:45 UTC 2024', machine='x86_64')

.

==================================================================================== 1 passed in 0.40s =====================================================================================

Remove all packages in environment /home/amanks/miniconda3/envs/issue_22305:

```