### PR TITLE
Add --use-library-version flag to run-tool for specifying a library version

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ To run the tool in a bug's environment (e.g. pytorch issue_117033)
 $> run-tool --container freefuzz --library-name pytorch --bug-id 117033 --run-script tool-integration/FreeFuzz/run_freefuzz_docker.sh
 ```
 
+Alternatively, to run the tool by specifying a library version instead of a bug ID (e.g., torch version 2.3.1):
+
+```Shell
+$> run-tool --container freefuzz --library-name pytorch --use-library-version 2.3.1 --run-script tool-integration/FreeFuzz/run_freefuzz_docker.sh
+```
+
 Sample output:
 
 ```Shell

--- a/framework/run-tool
+++ b/framework/run-tool
@@ -8,14 +8,15 @@ hash conda 2>/dev/null || { echo >&2 "I require conda but it's not installed.  A
 usage="
 -l library-name (mandatory)
   The id of the library for which the information shall be printed. Options: jax, pytorch, tensorflow
--i bug-id (mandatory)
+-i bug-id (optional if -u is provided)
   The bug number of the library-name for which the information shall be printed.
 -c container (mandatory)
   The docker container that contains the testing tool.
 -r run-script (mandatory)
   The path to the script relative to the root directory of the repository (or absolute path) that can execute the testing tool.
+-u use-library-version (optional)
+  The version of the library for which the first bug-id will be retrieved automatically.
 "
-
 
 function usage {
 cat <<-____HALP
@@ -31,7 +32,6 @@ case $1 in
      exit 0;;
 esac
 
-
 # before running through `getopts`, translate out convenient long-versions
 for opt in "$@"; do
     shift
@@ -40,18 +40,20 @@ for opt in "$@"; do
       '--bug-id')          set -- "$@" '-i' ;;
       '--container')       set -- "$@" '-c' ;;
       '--run-script')      set -- "$@" '-r' ;;
+      '--use-library-version') set -- "$@" '-u' ;;
       *)                   set -- "$@" "${opt}" ;;
     esac
 done
 
 ### read the flag and assign values to corresponding variables
-while getopts :l:i:c:r: flag
+while getopts :l:i:c:r:u: flag
 do
     case "${flag}" in
         l) library_name=${OPTARG};;
         i) bug_id=${OPTARG};;
         c) container=${OPTARG};;
         r) run_script=${OPTARG};;
+        u) library_version=${OPTARG};;
         \?) echo "invalid option: -$OPTARG."
             usage
             exit 1
@@ -77,9 +79,29 @@ if ! [[ "$library_name" =~ ^(jax|pytorch|tensorflow)$ ]]; then
     exit    
 fi
 
+### If -u is provided, fetch bug_id from stats output
+if [ -n "$library_version" ]; then
+    bug_id=$(stats -l "$library_name" -p none | awk -v version="$library_version" '
+        BEGIN { found = 0 }
+        /# Bug library version breakdown:/ { found = 1; next }
+        found && match($0, /^[[:space:]]*([^:]+):[[:space:]]*([0-9, ]+)/, arr) {
+            if (arr[1] == version) {
+                split(arr[2], bug_ids, ",");
+                gsub(/[[:space:],]/, "", bug_ids[1]);
+                print bug_ids[1];
+                exit;
+            }
+        }')
+    if [ -z "$bug_id" ]; then
+        echo "Could not find an issue number for version $library_version"
+        exit 1
+    fi
+    echo "Using bug-id $bug_id for library $library_name version $library_version"
+fi
 
-### bug_id is mandatory
-if [ "$bug_id" == "" ]; then 
+### bug_id is mandatory only if -u is not provided
+if [ -z "$bug_id" ] && [ -z "$library_version" ]; then
+    echo "Please provide bug id (-i) or library version (-u)"
     usage
     exit
 fi
@@ -95,7 +117,6 @@ if ! ls $home_location/$library_name | cut -d\_ -f2 | grep $bug_id > /dev/null ;
     echo "could not find bug-id $bug_id for $library_name"
     exit
 fi
-
 
 (
     cd ${home_location}/${library_name}/issue_${bug_id};


### PR DESCRIPTION
Closes: #202 

```Shell
(base) amanks@fedoravm:~/bugsindlls$ run-tool --container freefuzz --library-name pytorch --use-library-version 2.3.1
Using bug-id 129742 for library pytorch version 2.3.1
Reproducing the bug
no change     /home/amanks/miniconda3/condabin/conda
no change     /home/amanks/miniconda3/bin/conda
no change     /home/amanks/miniconda3/bin/conda-env
no change     /home/amanks/miniconda3/bin/activate
no change     /home/amanks/miniconda3/bin/deactivate
no change     /home/amanks/miniconda3/etc/profile.d/conda.sh
no change     /home/amanks/miniconda3/etc/fish/conf.d/conda.fish
no change     /home/amanks/miniconda3/shell/condabin/Conda.psm1
no change     /home/amanks/miniconda3/shell/condabin/conda-hook.ps1
no change     /home/amanks/miniconda3/lib/python3.12/site-packages/xontrib/conda.xsh
no change     /home/amanks/miniconda3/etc/profile.d/conda.csh
no change     /home/amanks/.bashrc
No action taken.
Channels:
 - defaults
Platform: linux-64
Collecting package metadata (repodata.json): done
Solving environment: done

## Package Plan ##

  environment location: /home/amanks/miniconda3/envs/issue_129742

  added / updated specs:
    - pip
    - python==3.10


The following NEW packages will be INSTALLED:

  _libgcc_mutex      pkgs/main/linux-64::_libgcc_mutex-0.1-main 
  _openmp_mutex      pkgs/main/linux-64::_openmp_mutex-5.1-1_gnu 
  bzip2              pkgs/main/linux-64::bzip2-1.0.8-h5eee18b_6 
  ca-certificates    pkgs/main/linux-64::ca-certificates-2025.2.25-h06a4308_0 
  ld_impl_linux-64   pkgs/main/linux-64::ld_impl_linux-64-2.40-h12ee557_0 
  libffi             pkgs/main/linux-64::libffi-3.3-he6710b0_2 
  libgcc-ng          pkgs/main/linux-64::libgcc-ng-11.2.0-h1234567_1 
  libgomp            pkgs/main/linux-64::libgomp-11.2.0-h1234567_1 
  libstdcxx-ng       pkgs/main/linux-64::libstdcxx-ng-11.2.0-h1234567_1 
  libuuid            pkgs/main/linux-64::libuuid-1.41.5-h5eee18b_0 
  ncurses            pkgs/main/linux-64::ncurses-6.4-h6a678d5_0 
  openssl            pkgs/main/linux-64::openssl-1.1.1w-h7f8727e_0 
  pip                pkgs/main/linux-64::pip-25.0-py310h06a4308_0 
  python             pkgs/main/linux-64::python-3.10.0-h12debd9_5 
  readline           pkgs/main/linux-64::readline-8.2-h5eee18b_0 
  setuptools         pkgs/main/linux-64::setuptools-75.8.0-py310h06a4308_0 
  sqlite             pkgs/main/linux-64::sqlite-3.45.3-h5eee18b_0 
  tk                 pkgs/main/linux-64::tk-8.6.14-h39e8969_0 
  tzdata             pkgs/main/noarch::tzdata-2025a-h04d1e81_0 
  wheel              pkgs/main/linux-64::wheel-0.45.1-py310h06a4308_0 
  xz                 pkgs/main/linux-64::xz-5.6.4-h5eee18b_1 
  zlib               pkgs/main/linux-64::zlib-1.2.13-h5eee18b_1 



Downloading and Extracting Packages:

Preparing transaction: done
Verifying transaction: done
Executing transaction: done
#
# To activate this environment, use
#
#     $ conda activate issue_129742
#
# To deactivate an active environment, use
#
#     $ conda deactivate

Looking in indexes: https://pypi.org/simple, https://download.pytorch.org/whl/cpu
Collecting exceptiongroup==1.2.2 (from -r requirements.txt (line 1))
  Using cached exceptiongroup-1.2.2-py3-none-any.whl.metadata (6.6 kB)
Collecting filelock==3.13.1 (from -r requirements.txt (line 2))
  Using cached https://download.pytorch.org/whl/filelock-3.13.1-py3-none-any.whl.metadata (2.8 kB)
Collecting fsspec==2024.2.0 (from -r requirements.txt (line 3))
  Using cached https://download.pytorch.org/whl/fsspec-2024.2.0-py3-none-any.whl (170 kB)
Collecting iniconfig==2.0.0 (from -r requirements.txt (line 4))
  Using cached iniconfig-2.0.0-py3-none-any.whl.metadata (2.6 kB)
Collecting Jinja2==3.1.3 (from -r requirements.txt (line 5))
  Using cached https://download.pytorch.org/whl/Jinja2-3.1.3-py3-none-any.whl (133 kB)
Collecting MarkupSafe==2.1.5 (from -r requirements.txt (line 6))
  Using cached https://download.pytorch.org/whl/MarkupSafe-2.1.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (25 kB)
Collecting mpmath==1.3.0 (from -r requirements.txt (line 7))
  Using cached https://download.pytorch.org/whl/mpmath-1.3.0-py3-none-any.whl (536 kB)
Collecting networkx==3.2.1 (from -r requirements.txt (line 8))
  Using cached https://download.pytorch.org/whl/networkx-3.2.1-py3-none-any.whl (1.6 MB)
Collecting numpy==1.26.3 (from -r requirements.txt (line 9))
  Using cached https://download.pytorch.org/whl/numpy-1.26.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (18.2 MB)
Collecting packaging==24.1 (from -r requirements.txt (line 10))
  Using cached https://download.pytorch.org/whl/packaging-24.1-py3-none-any.whl (53 kB)
Collecting pillow==10.2.0 (from -r requirements.txt (line 11))
  Using cached https://download.pytorch.org/whl/pillow-10.2.0-cp310-cp310-manylinux_2_28_x86_64.whl (4.5 MB)
Collecting pluggy==1.5.0 (from -r requirements.txt (line 12))
  Using cached pluggy-1.5.0-py3-none-any.whl.metadata (4.8 kB)
Collecting pytest==8.3.2 (from -r requirements.txt (line 13))
  Using cached pytest-8.3.2-py3-none-any.whl.metadata (7.5 kB)
Collecting sympy==1.12 (from -r requirements.txt (line 14))
  Using cached https://download.pytorch.org/whl/sympy-1.12-py3-none-any.whl (5.7 MB)
Collecting tomli==2.0.1 (from -r requirements.txt (line 15))
  Using cached tomli-2.0.1-py3-none-any.whl.metadata (8.9 kB)
Collecting torch==2.3.1+cpu (from -r requirements.txt (line 17))
  Using cached https://download.pytorch.org/whl/cpu/torch-2.3.1%2Bcpu-cp310-cp310-linux_x86_64.whl (190.4 MB)
Collecting torchaudio==2.3.1+cpu (from -r requirements.txt (line 18))
  Using cached https://download.pytorch.org/whl/cpu/torchaudio-2.3.1%2Bcpu-cp310-cp310-linux_x86_64.whl (1.7 MB)
Collecting torchvision==0.18.1+cpu (from -r requirements.txt (line 19))
  Using cached https://download.pytorch.org/whl/cpu/torchvision-0.18.1%2Bcpu-cp310-cp310-linux_x86_64.whl (1.6 MB)
Collecting typing_extensions==4.9.0 (from -r requirements.txt (line 20))
  Using cached https://download.pytorch.org/whl/typing_extensions-4.9.0-py3-none-any.whl (32 kB)
Using cached exceptiongroup-1.2.2-py3-none-any.whl (16 kB)
Using cached https://download.pytorch.org/whl/filelock-3.13.1-py3-none-any.whl (11 kB)
Using cached iniconfig-2.0.0-py3-none-any.whl (5.9 kB)
Using cached pluggy-1.5.0-py3-none-any.whl (20 kB)
Using cached pytest-8.3.2-py3-none-any.whl (341 kB)
Using cached tomli-2.0.1-py3-none-any.whl (12 kB)
Installing collected packages: mpmath, typing_extensions, tomli, sympy, pluggy, pillow, packaging, numpy, networkx, MarkupSafe, iniconfig, fsspec, filelock, exceptiongroup, pytest, Jinja2, torch, torchvision, torchaudio
Successfully installed Jinja2-3.1.3 MarkupSafe-2.1.5 exceptiongroup-1.2.2 filelock-3.13.1 fsspec-2024.2.0 iniconfig-2.0.0 mpmath-1.3.0 networkx-3.2.1 numpy-1.26.3 packaging-24.1 pillow-10.2.0 pluggy-1.5.0 pytest-8.3.2 sympy-1.12 tomli-2.0.1 torch-2.3.1+cpu torchaudio-2.3.1+cpu torchvision-0.18.1+cpu typing_extensions-4.9.0
/home/amanks/miniconda3/envs/issue_129742/lib/python3.10/runpy.py:126: RuntimeWarning: 'torch.utils.collect_env' found in sys.modules after import of package 'torch.utils', but prior to execution of 'torch.utils.collect_env'; this may result in unpredictable behaviour
  warn(RuntimeWarning(msg))
Collecting environment information...
PyTorch version: 2.3.1+cpu
Is debug build: False
CUDA used to build PyTorch: None
ROCM used to build PyTorch: N/A

OS: Fedora Linux 40 (Workstation Edition) (x86_64)
GCC version: (GCC) 14.2.1 20240912 (Red Hat 14.2.1-3)
Clang version: Could not collect
CMake version: Could not collect
Libc version: glibc-2.39

Python version: 3.10.0 (default, Mar  3 2022, 09:58:08) [GCC 7.5.0] (64-bit runtime)
Python platform: Linux-6.12.11-100.fc40.x86_64-x86_64-with-glibc2.39
Is CUDA available: False
CUDA runtime version: No CUDA
CUDA_MODULE_LOADING set to: N/A
GPU models and configuration: No CUDA
Nvidia driver version: No CUDA
cuDNN version: No CUDA
HIP runtime version: N/A
MIOpen runtime version: N/A
Is XNNPACK available: True

CPU:
Architecture:                         x86_64
CPU op-mode(s):                       32-bit, 64-bit
Address sizes:                        48 bits physical, 48 bits virtual
Byte Order:                           Little Endian
CPU(s):                               6
On-line CPU(s) list:                  0-5
Vendor ID:                            AuthenticAMD
Model name:                           AMD Ryzen 7 7735U with Radeon Graphics
CPU family:                           25
Model:                                68
Thread(s) per core:                   1
Core(s) per socket:                   6
Socket(s):                            1
Stepping:                             1
BogoMIPS:                             5389.82
Flags:                                fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm rep_good nopl cpuid extd_apicid tsc_known_freq pni pclmulqdq ssse3 fma cx16 sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw perfctr_core ssbd ibrs ibpb stibp vmmcall fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves clzero xsaveerptr wbnoinvd arat npt lbrv nrip_save tsc_scale vmcb_clean flushbyasid pausefilter pfthreshold v_vmsave_vmload vgif umip pku ospke vaes vpclmulqdq rdpid overflow_recov succor fsrm arch_capabilities
Virtualization:                       AMD-V
Hypervisor vendor:                    KVM
Virtualization type:                  full
L1d cache:                            384 KiB (6 instances)
L1i cache:                            384 KiB (6 instances)
L2 cache:                             3 MiB (6 instances)
L3 cache:                             96 MiB (6 instances)
NUMA node(s):                         1
NUMA node0 CPU(s):                    0-5
Vulnerability Gather data sampling:   Not affected
Vulnerability Itlb multihit:          Not affected
Vulnerability L1tf:                   Not affected
Vulnerability Mds:                    Not affected
Vulnerability Meltdown:               Not affected
Vulnerability Mmio stale data:        Not affected
Vulnerability Reg file data sampling: Not affected
Vulnerability Retbleed:               Not affected
Vulnerability Spec rstack overflow:   Vulnerable: Safe RET, no microcode
Vulnerability Spec store bypass:      Mitigation; Speculative Store Bypass disabled via prctl
Vulnerability Spectre v1:             Mitigation; usercopy/swapgs barriers and __user pointer sanitization
Vulnerability Spectre v2:             Mitigation; Retpolines; IBPB conditional; IBRS_FW; STIBP disabled; RSB filling; PBRSB-eIBRS Not affected; BHI Not affected
Vulnerability Srbds:                  Not affected
Vulnerability Tsx async abort:        Not affected

Versions of relevant libraries:
[pip3] numpy==1.26.3
[pip3] torch==2.3.1+cpu
[pip3] torchaudio==2.3.1+cpu
[pip3] torchvision==0.18.1+cpu
[conda] numpy                     1.26.3                   pypi_0    pypi
[conda] torch                     2.3.1+cpu                pypi_0    pypi
[conda] torchaudio                2.3.1+cpu                pypi_0    pypi
[conda] torchvision               0.18.1+cpu               pypi_0    pypi
======================================================================================== test session starts ========================================================================================
platform linux -- Python 3.10.0, pytest-8.3.2, pluggy-1.5.0
rootdir: /home/amanks/bugsindlls/pytorch/issue_129742
collected 1 item                                                                                                                                                                                    

test_issue_129742.py Pytorch issue no. 129742
Unsupported: hasattr TensorVariable attr

from user code:
   File "/home/amanks/bugsindlls/pytorch/issue_129742/test_issue_129742.py", line 7, in f
    if hasattr(x, "attr"):

Set TORCH_LOGS="+dynamo" and TORCHDYNAMO_VERBOSE=1 for more information


You can suppress this exception and fall back to eager by setting:
    import torch._dynamo
    torch._dynamo.config.suppress_errors = True

.

========================================================================================= 1 passed in 1.56s =========================================================================================

Remove all packages in environment /home/amanks/miniconda3/envs/issue_129742:

Updating environment in the container of the testing tool
Successfully copied 14.3kB to freefuzz:/tmp/issue_129742
Error response from daemon: No such container: freefuzz
Error response from daemon: No such container: freefuzz
Running the testing tool on the environment of the bug
pytorch: pytorch: Is a directory
```